### PR TITLE
Reiniciar resultado tras cambios de parámetros

### DIFF
--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -82,6 +82,9 @@
     flex-direction: column;
     gap: 10px;
   }
+  .card > .row + .row {
+    margin-top: 20px;
+  }
   .row.da-actions {
     display: flex;
     align-items: center;
@@ -100,7 +103,7 @@
     text-transform: uppercase;
     letter-spacing: 0.05em;
     color: rgba(226, 232, 240, 0.78);
-    margin-bottom: 8px;
+    margin-bottom: 0;
     display: block;
   }
   select, input[type="number"], input[type="text"] {
@@ -176,7 +179,12 @@
     letter-spacing: 0.03em;
     text-transform: uppercase;
   }
-  .pill.ok { background: rgba(34, 197, 94, 0.18); color: #4ade80; border: 1px solid rgba(34, 197, 94, 0.45); }
+  .pill.ok {
+    background: #14532d;
+    color: #f4fff4;
+    border: 1px solid rgba(74, 222, 128, 0.7);
+    box-shadow: inset 0 1px 0 rgba(209, 250, 229, 0.2);
+  }
   .pill.bad { background: rgba(244, 63, 94, 0.15); color: #fb7185; border: 1px solid rgba(244, 63, 94, 0.45); }
   .pill.warn { background: rgba(245, 158, 11, 0.16); color: #fcd34d; border: 1px solid rgba(245, 158, 11, 0.45); }
   .legend {
@@ -187,7 +195,9 @@
     justify-content: center;
   }
   .result-meta { margin-top: 18px; text-align: center; }
-  .result-meta h2 { margin-top: 0; }
+  .result-title { margin: 0 0 12px; font-size: 20px; letter-spacing: 0.02em; text-transform: uppercase; }
+  .result-status { min-height: 40px; display: flex; align-items: center; justify-content: center; margin-bottom: 10px; }
+  .result-status .pill { font-size: 14px; padding: 8px 18px; }
   .result-meta .small { margin: 0 auto; max-width: 420px; text-align: center; }
   .svgbox {
     position: relative;
@@ -299,8 +309,10 @@
           <label>Sistema / fluido de la tubería</label>
           <select id="system"></select>
         </div>
+      </div>
+      <div class="row">
         <div>
-          <label>Ubicación (espacio o tanque)</label>
+          <label>Ubicación (espacio o tanque) a pasar</label>
           <select id="location"></select>
         </div>
       </div>
@@ -309,11 +321,10 @@
         <div>
           <label>Material</label>
           <select id="material">
-            <option value="steel">Acero al carbono (Tabla 11.6)</option>
-            <option value="stainless">Acero inoxidable austenítico (Tabla 11.7)</option>
-            <option value="copper_family">Cobre y aleaciones de cobre (Tabla 11.8)</option>
+            <option value="steel">Acero al carbono</option>
+            <option value="stainless">Acero inoxidable austenítico</option>
+            <option value="copper_family">Cobre y aleaciones de cobre</option>
           </select>
-          <div id="groupBox" class="hint">Grupo (solo steel): <b id="groupHint">—</b></div>
           <div id="copperSub" class="hidden">
             <label for="copperType">Subtipo</label>
             <select id="copperType">
@@ -349,7 +360,8 @@
         <span class="pill warn">Especial (–)</span>
       </div>
       <div class="result-meta">
-        <h2 id="headline">—</h2>
+        <h2 class="result-title">Resultado de análisis</h2>
+        <div id="headline" class="result-status">—</div>
         <div id="explain" class="small">—</div>
       </div>
 
@@ -607,9 +619,12 @@ function drawViz({status,place,system,s}){
   const tankX=pad,tankY=pad,tankW=w-pad*2,tankH=h-pad*2;
   const pipeH=Math.max(32,tankH*0.2);
   const pipeY=tankY+tankH/2;
-  const pipeMargin=Math.max(16,tankW*0.04);
-  const pipeW=Math.max(0,tankW-pipeMargin*2);
-  const pipeX=tankX+pipeMargin;
+  const availableLeft=Math.max(0,tankX-6);
+  const availableRight=Math.max(0,w-(tankX+tankW)-6);
+  const maxExtension=Math.max(0,Math.min(availableLeft,availableRight));
+  const pipeExtension=Math.min(Math.max(18,tankW*0.06),maxExtension);
+  const pipeX=tankX-pipeExtension;
+  const pipeW=Math.max(0,tankW+pipeExtension*2);
   const color=status==='ok'?'var(--ok)':status==='warn'?'var(--warn)':'var(--bad)';
   const tankTop=status==='bad'?'#40202b':status==='warn'?'#3a2c15':'#1f2937';
   const tankBottom=status==='bad'?'#1a0c12':status==='warn'?'#17100a':'#0b1120';
@@ -709,10 +724,17 @@ function setSchLineValue(text){
   schLine.textContent=text && text.trim()?text:' ';
 }
 
+function updateGroupHint(value){
+  const hint=document.getElementById('groupHint');
+  if(hint){
+    hint.textContent=value;
+  }
+}
+
 function resetResults(){
   document.getElementById('headline').textContent='—';
   document.getElementById('explain').textContent='—';
-  document.getElementById('groupHint').textContent='—';
+  updateGroupHint('—');
   document.getElementById('outTbl').style.display='none';
   setSLineValue(null);
   setSchLineValue('');
@@ -811,7 +833,7 @@ function calc(){
     drawViz({status:'warn', place:locationSel, system});
     document.getElementById('headline').innerHTML='<span class="pill warn">Especial (–)</span>';
     document.getElementById('explain').textContent=MSG_AGREEMENT;
-    document.getElementById('groupHint').textContent='—';
+    updateGroupHint('—');
     setSLineValue(null);
     setSchLineValue('SCH NO disponible');
     table.style.display='none';
@@ -822,7 +844,7 @@ function calc(){
     drawViz({status:'bad',place:locationSel,system});
     document.getElementById('headline').innerHTML='<span class="pill bad">No compatible</span>';
     document.getElementById('explain').innerHTML='La tabla normativa (11.5) marca “X”: la tubería no debe instalarse en esta ubicación.';
-    document.getElementById('groupHint').textContent='—';
+    updateGroupHint('—');
     setSLineValue(null);
     setSchLineValue('SCH NO disponible');
     table.style.display='none';
@@ -836,7 +858,7 @@ function calc(){
 
   if(mat==='steel'){
     group=symbol;
-    document.getElementById('groupHint').textContent=group;
+    updateGroupHint(group);
     const rec=findScheduleByOd(Number(daKey));
     if(!rec){
       drawViz({status:'bad',place:locationSel,system});
@@ -861,7 +883,7 @@ function calc(){
     }
     rule=`Steel grupo <b>${group}</b> · Tabla 11.6 · Selección: ${selectionLabel}.`;
   } else if(mat==='stainless'){
-    document.getElementById('groupHint').textContent='—';
+    updateGroupHint('—');
     const rec=findScheduleByOd(Number(daKey));
     if(!rec){
       drawViz({status:'bad',place:locationSel,system});
@@ -886,7 +908,7 @@ function calc(){
     }
     rule=`Austenitic stainless steel · Tabla 11.7 · Selección: ${selectionLabel}.`;
   } else if(mat==='copper_family'){
-    document.getElementById('groupHint').textContent='—';
+    updateGroupHint('—');
     const sub=copperTypeSel.value;
     const rangeRow=findTable118Range(String(daKey));
     if(!rangeRow){
@@ -912,7 +934,7 @@ function calc(){
     const subtypeText=copperTypeSel.options[copperTypeSel.selectedIndex].text;
     rule=`Cobre y aleaciones · Tabla 11.8 · Rango: ${selectionLabel}. Subtipo: ${subtypeText}.`;
   } else {
-    document.getElementById('groupHint').textContent='—';
+    updateGroupHint('—');
   }
 
   drawViz({status:'ok',place:locationSel,system,s});
@@ -966,10 +988,27 @@ function calc(){
 // INIT
 fillSelect('system', SYSTEMS, SYSTEMS_LABELS);
 fillSelect('location', SPACES, SPACES_LABELS);
+
+function invalidateResults({preserveHelp=false,message=''}={}){
+  resetResults();
+  if(message){
+    daHelp.textContent=message;
+    return;
+  }
+  if(preserveHelp){
+    return;
+  }
+  const validated=getDaSelection();
+  const hasValidated=validated.key!=null && validated.key!=='';
+  daHelp.textContent=hasValidated
+    ? 'Parámetros cambiaron. Pulse Validar para recalcular.'
+    : 'Seleccione un diámetro y pulse Validar.';
+}
+
 ['system','location'].forEach(id=>{
   const el=document.getElementById(id);
-  el.addEventListener('change',calc);
-  el.addEventListener('input',calc);
+  el.addEventListener('change',()=>invalidateResults());
+  el.addEventListener('input',()=>invalidateResults());
 });
 function handleMaterialChange(){
   toggleCopperSub();
@@ -977,13 +1016,12 @@ function handleMaterialChange(){
   selectedDaText='';
   populateDaOptions();
   setDaSelection(null,'');
-  daHelp.textContent='Seleccione un diámetro y pulse Validar.';
-  resetResults();
+  invalidateResults({message:'Seleccione un diámetro y pulse Validar.'});
 }
 materialSel.addEventListener('change',handleMaterialChange);
 materialSel.addEventListener('input',handleMaterialChange);
 copperTypeSel.addEventListener('change',()=>{
-  calc();
+  invalidateResults();
 });
 daSelect.addEventListener('change',()=>{
   const opt=daSelect.options[daSelect.selectedIndex];
@@ -995,9 +1033,10 @@ daSelect.addEventListener('change',()=>{
   if(!opt.value){
     selectedDaKey=null;
     selectedDaText='';
-    daHelp.textContent='Seleccione un diámetro y pulse Validar.';
+    invalidateResults({message:'Seleccione un diámetro y pulse Validar.'});
     return;
   }
+  invalidateResults({preserveHelp:true});
   selectedDaKey=opt.value;
   selectedDaText=opt.textContent;
   daHelp.textContent=`Seleccionado: ${selectedDaText}. Pulse Validar para aplicar.`;


### PR DESCRIPTION
## Summary
- Restablecer el indicador de resultado cuando el usuario modifica sistema, ubicación, material, subtipo o diámetro para exigir una nueva validación
- Añadir mensajes de ayuda que avisan que hay cambios pendientes y mantener la selección validada hasta que se confirme
- Ajustar la etiqueta del selector de ubicación a "Ubicación (espacio o tanque) a pasar" según la nueva redacción

## Testing
- Manual verification in browser
- Screenshot capture via Playwright

------
https://chatgpt.com/codex/tasks/task_e_68d6a3a1ca008321b9b83bbaf476f8f6