### PR TITLE
Improve header logo spacing on compatibility page

### DIFF
--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -51,6 +51,7 @@
     justify-content: space-between;
     gap: 24px;
     flex-wrap: wrap;
+    margin-bottom: 32px;
   }
   .page-header .header-copy { flex: 1 1 380px; min-width: 260px; }
   .page-header .header-brand {
@@ -59,12 +60,16 @@
     display: flex;
     align-items: flex-start;
     justify-content: flex-end;
+    padding: 12px;
+    border-radius: 22px;
+    background: rgba(15, 23, 42, 0.5);
+    backdrop-filter: blur(10px);
+    box-shadow: 0 16px 40px rgba(8, 47, 73, 0.35);
   }
   .page-header .header-brand img {
     max-width: 100%;
     height: auto;
-    border-radius: 16px;
-    box-shadow: 0 10px 28px rgba(8, 47, 73, 0.35);
+    border-radius: 14px;
   }
   h1 {
     font-size: clamp(26px, 4vw, 38px);


### PR DESCRIPTION
## Summary
- add spacing below the header to separate the logo from the results card
- wrap the logo in a translucent, blurred container to give it more breathing room

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6e5e631d48321b8921f0b5cb93219