### PR TITLE
Refine union cards layout and styling

### DIFF
--- a/asesor-grip-type-nobabel.html
+++ b/asesor-grip-type-nobabel.html
@@ -21,16 +21,36 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     /* ===== Mejoras de presentación (no tocan la lógica) ===== */
+    .result-row {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 18px;
+      align-items: stretch;
+    }
+
     .result-card {
+      display: flex;
+      flex-direction: column;
+      min-height: 560px;
+      padding: 18px 18px 20px;
       border-radius: 14px;
-      padding: 18px 18px 8px 18px;
       background: rgba(255, 255, 255, 0.02);
       border: 1px solid rgba(255, 255, 255, 0.08);
     }
 
+    .result-card--allowed {
+      border-color: rgba(34, 197, 94, 0.28);
+      box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.15);
+    }
+
+    .result-card--blocked {
+      border-color: rgba(244, 63, 94, 0.28);
+      box-shadow: 0 0 0 1px rgba(244, 63, 94, 0.12);
+    }
+
     .result-header {
       text-align: center;
-      margin-bottom: 14px;
+      margin-bottom: 10px;
       line-height: 1.2;
     }
 
@@ -43,39 +63,45 @@
     .result-title-en {
       display: block;
       font-size: 0.95rem;
-      opacity: 0.7;
+      opacity: 0.75;
       margin-top: 2px;
     }
 
-    /* Lista de opciones más “lineal” y respirada */
+    .block-subtitle {
+      margin: 8px 0 16px;
+      opacity: 0.95;
+    }
+
+    .result-body {
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: column;
+    }
+
     .option-list {
       list-style: none;
       margin: 0;
       padding: 0;
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: 8px;
-    }
-
-    @media (min-width: 900px) {
-      .option-list {
-        grid-template-columns: 1fr 1fr;
-      }
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
     }
 
     .option-item {
+      width: 100%;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 12px;
-      border: 1px dashed rgba(255, 255, 255, 0.12);
-      border-radius: 10px;
-      padding: 10px 12px;
+      gap: 14px;
+      padding: 14px 16px;
+      min-height: 86px;
+      border: 1px dashed rgba(255, 255, 255, 0.14);
+      border-radius: 12px;
       background: rgba(255, 255, 255, 0.03);
     }
 
     .option-text {
-      line-height: 1.25;
+      line-height: 1.22;
     }
 
     .option-es {
@@ -85,26 +111,54 @@
 
     .option-en {
       display: block;
-      opacity: 0.75;
-      font-size: 0.92rem;
+      opacity: 0.85;
+      font-size: 0.95rem;
     }
 
-    /* Botón "ver" existente: solo aseguremos consistencia */
     .option-actions .chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 8px 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.28);
+      background: rgba(255, 255, 255, 0.08);
+      color: inherit;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      transition: background 0.2s ease, border-color 0.2s ease;
       white-space: nowrap;
     }
 
-    /* Estados no permitidos / deshabilitados */
+    .option-actions .chip:hover {
+      background: rgba(255, 255, 255, 0.14);
+      border-color: rgba(255, 255, 255, 0.4);
+    }
+
+    .option-actions .chip:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+      background: rgba(148, 163, 184, 0.1);
+      border-color: rgba(148, 163, 184, 0.25);
+    }
+
     .option-item.disabled {
       opacity: 0.55;
-      filter: grayscale(20%);
+      filter: grayscale(15%);
       text-decoration: line-through;
     }
 
-    /* Bloque “se puede usar / notas” más claro */
-    .block-subtitle {
-      margin: 6px 0 12px 0;
-      opacity: 0.9;
+    @media (max-width: 900px) {
+      .result-row {
+        grid-template-columns: 1fr;
+      }
+
+      .result-card {
+        min-height: 0;
+      }
     }
   </style>
 </head>
@@ -748,7 +802,7 @@
                       Sistema: <b>${tGroup(evaluation.sys.group)} → ${tSystem(evaluation.sys)}</b> · Condición del sistema (tabla): <b>${evaluation.sys.pipeSystemClass}</b> · Ensayo fuego: <b>${evaluation.sys.fireTest}</b>
                     </div>
 
-                    <div className="grid md:grid-cols-3 gap-4">
+                    <div className="result-row">
                       <${CategoryCard}
                         title="Pipe unions"
                         allowed=${evaluation.categories.pipeUnions}
@@ -900,39 +954,47 @@
     function CategoryCard({ title, allowed, details, items, onView }) {
       const { es: titleEs, en: titleEn } = biTitle(title);
       const subtitleText = `${allowed ? "Se puede usar" : "No se puede usar"}${details ? ` • ${details}` : ""}`;
-      const wrapperClass = `result-card ${allowed ? "border-emerald-600/60 bg-emerald-500/5" : "border-rose-600/60 bg-rose-500/5"}`;
       const listItems = Array.isArray(items) ? items : [];
+      const cardIds = {
+        "Pipe unions": "card-PIPE",
+        "Compression couplings": "card-COMPRESSION",
+        "Slip-on Joints": "card-SLIP",
+      };
+      const cardId = cardIds[title];
+      const cardStateClass = allowed ? " result-card--allowed" : " result-card--blocked";
 
-      return html`<div className=${wrapperClass}>
+      return html`<div className=${`result-card${cardStateClass}`} id=${cardId || undefined}>
         <div className="result-header" aria-live="polite">
           <span className="result-title-es">${titleEs}</span>
           <span className="result-title-en">(${titleEn})</span>
         </div>
         <div className="block-subtitle">${subtitleText}</div>
-        <ul className="option-list">
-          ${listItems.map((item, idx) => {
-            const { es, en } = biLabel(item);
-            const optionId = item.id ?? item.kind ?? idx;
-            const isDisabled = item.disabled === true || item.available === false;
-            return html`<li key=${optionId} className=${`option-item${isDisabled ? " disabled" : ""}`}>
-              <div className="option-text">
-                <span className="option-es">${es}</span>
-                <span className="option-en">(${en})</span>
-              </div>
-              <div className="option-actions">
-                <button
-                  type="button"
-                  className="chip text-xs px-2 py-0.5 rounded-lg border border-slate-600 hover:bg-slate-700 disabled:opacity-60 disabled:hover:bg-transparent"
-                  data-id=${optionId}
-                  disabled=${isDisabled}
-                  onClick=${() => onView(item.kind)}
-                >
-                  ver
-                </button>
-              </div>
-            </li>`;
-          })}
-        </ul>
+        <div className="result-body">
+          <ul className="option-list">
+            ${listItems.map((item, idx) => {
+              const { es, en } = biLabel(item);
+              const optionId = item.id ?? item.kind ?? idx;
+              const isDisabled = item.disabled === true || item.available === false;
+              return html`<li key=${optionId} className=${`option-item${isDisabled ? " disabled" : ""}`}>
+                <div className="option-text">
+                  <span className="option-es">${es}</span>
+                  <span className="option-en">(${en})</span>
+                </div>
+                <div className="option-actions">
+                  <button
+                    type="button"
+                    className="chip"
+                    data-id=${optionId}
+                    disabled=${isDisabled}
+                    onClick=${() => onView(item.kind)}
+                  >
+                    ver
+                  </button>
+                </div>
+              </li>`;
+            })}
+          </ul>
+        </div>
       </div>`;
     }
 


### PR DESCRIPTION
## Summary
- redesign the union result row into a three-card grid with responsive stacking and taller cards
- update card markup for bilingual headers, subtitles, and vertically stacked option lists with refreshed chip styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d73e836da883219526081fe73e018a