### PR TITLE
Alinea el logo del asesor con la portada

### DIFF
--- a/asesor-grip-type-nobabel.html
+++ b/asesor-grip-type-nobabel.html
@@ -775,26 +775,28 @@
 
       return html`<div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800 text-slate-100">
         <header className="sticky top-0 z-10 backdrop-blur bg-slate-900/75 border-b border-slate-700/70">
-          <div className="max-w-7xl mx-auto px-4 py-4">
-            <div className="flex items-center gap-4">
-              <div className="flex-shrink-0">
-                <img
-                  src="./assets/joints/cotec.jpg"
-                  alt="COTECMAR"
-                  className="w-20 md:w-24 rounded-2xl shadow-lg ring-1 ring-slate-700/50"
-                />
-              </div>
-              <div className="flex-1 text-center">
-                <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-slate-100">
+          <div className="max-w-7xl mx-auto px-4 py-6">
+            <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-6">
+              <div className="md:max-w-3xl">
+                <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-slate-100 text-left">
                   Asesor Grip‑Type LR (Slip‑on Joints) – v0.7 · Naval Ships
                 </h1>
-                <div className="mt-2 hidden md:flex items-center justify-center gap-2 text-sm text-slate-300">
+                <div className="mt-3 hidden md:flex items-center gap-2 text-sm text-slate-300">
                   ${h(ShieldIcon, { className: "w-5 h-5" })}
                   <span>Lógica: 1.5.3 → ubicación → 1.5.4 (clase/OD). Notas en español.</span>
                 </div>
-                <p className="mt-2 text-xs text-slate-300 md:hidden">
+                <p className="mt-3 text-xs text-slate-300 md:hidden text-left">
                   Lógica: 1.5.3 → ubicación → 1.5.4 (clase/OD). Notas en español.
                 </p>
+              </div>
+              <div className="md:ml-auto flex-shrink-0 self-center md:self-start">
+                <div className="flex justify-end rounded-[22px] bg-slate-900/60 backdrop-blur-xl shadow-2xl ring-1 ring-slate-700/60 p-3">
+                  <img
+                    src="./assets/joints/cotec.jpg"
+                    alt="COTECMAR"
+                    className="w-20 md:w-24 rounded-2xl shadow-lg"
+                  />
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- reorganize the header layout of the asesor Grip-Type page to mirror the index hero
- add a styled container so the Cotecmar logo sits on the right with the same visual treatment

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db4a2939d8832188ae783e69c99715