### PR TITLE
Evita encabezado fijo en asesor Grip Type

### DIFF
--- a/asesor-grip-type-nobabel.html
+++ b/asesor-grip-type-nobabel.html
@@ -819,7 +819,7 @@
       const usedClass = computeUsedClass(sys);
 
       return html`<div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800 text-slate-100">
-        <header className="sticky top-0 z-10 backdrop-blur bg-slate-900/75 border-b border-slate-700/70">
+        <header className="backdrop-blur bg-slate-900/75 border-b border-slate-700/70">
           <div className="max-w-7xl mx-auto px-4 py-6 w-full">
             <div className="page-header">
               <div className="header-copy md:max-w-3xl text-left">


### PR DESCRIPTION
## Summary
- elimina por completo el comportamiento sticky del encabezado en el asesor Grip Type para evitar que el contenido quede oculto en móviles

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbc22015048321908fc4342eb48a5e