### PR TITLE
Fix header layout regression on Grip Type advisor page

### DIFF
--- a/asesor-grip-type-nobabel.html
+++ b/asesor-grip-type-nobabel.html
@@ -820,7 +820,7 @@
 
       return html`<div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800 text-slate-100">
 
-          <div className="max-w-7xl mx-auto px-4 py-6 w-full">
+          <header className="max-w-7xl mx-auto px-4 py-6 w-full">
             <div className="page-header">
               <div className="header-copy md:max-w-3xl text-left">
                 <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-slate-100">
@@ -842,8 +842,7 @@
                 <img src="assets/joints/cotec.jpg" alt="COTECMAR" id="logoCotecmar" />
               </div>
             </div>
-          </div>
-        </header>
+          </header>
 
         <main className="max-w-7xl mx-auto p-4 space-y-6">
           <section className="bg-slate-950/40 rounded-2xl p-4 shadow space-y-4">


### PR DESCRIPTION
## Summary
- wrap the top banner of the Grip Type advisor in a semantic header element to restore the layout and prevent the grid from overlapping the title and logo

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dbc5a91b2c8321a998c8fab044c180