### PR TITLE
Simplify system dropdown labels

### DIFF
--- a/asesor-grip-type-multi.html
+++ b/asesor-grip-type-multi.html
@@ -513,7 +513,7 @@
                   ${groupedSystems.order.map((groupKey) => html`
                     <optgroup key=${groupKey} label=${tGroup(groupKey)}>
                       ${groupedSystems.byGroup.get(groupKey).map((item) => html`
-                        <option value=${item.id}>${`${tGroup(groupKey)} — ${tSystem(item.id)}`}</option>
+                        <option value=${item.id}>${tSystem(item.id)}</option>
                       `)}
                     </optgroup>
                   `)}


### PR DESCRIPTION
## Summary
- remove duplicated group names from the system selector options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddf73328c08321aaa62c24afad263d