### PR TITLE
Update system dropdown labels to avoid duplicated group text

### DIFF
--- a/asesor-grip-type-multi.html
+++ b/asesor-grip-type-multi.html
@@ -512,9 +512,10 @@
                 >
                   ${groupedSystems.order.map((groupKey) => html`
                     <optgroup key=${groupKey} label=${tGroup(groupKey)}>
-                      ${groupedSystems.byGroup.get(groupKey).map((item) => html`
-                        <option value=${item.id}>${`${tGroup(groupKey)} — ${tSystem(item.id)}`}</option>
-                      `)}
+                      ${groupedSystems.byGroup.get(groupKey).map((item) => {
+                        const systemLabel = tSystem(item.id) || item.system || item.id;
+                        return html`<option value=${item.id}>${systemLabel}</option>`;
+                      })}
                     </optgroup>
                   `)}
                 </select>


### PR DESCRIPTION
## Summary
- adjust the system selector so each option only shows the translated system label
- fall back to the raw system name or id when no translation is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddf7d1519c832197ef62b09ab1eb0e