### PR TITLE
Fix shared class limits between Naval and Ships rulesets

### DIFF
--- a/rulesets/index.js
+++ b/rulesets/index.js
@@ -1,9 +1,16 @@
 import naval from "./naval.js";
-import ships from "./ships.js";
+import shipsBase from "./ships.js";
 import ssc from "./ssc.js";
 
-if (!ships.CLASS_LIMITS) {
-  ships.CLASS_LIMITS = naval.CLASS_LIMITS;
-}
+const clone = (value) => (value ? JSON.parse(JSON.stringify(value)) : value);
 
-export const RULESETS = { naval, ships, ssc };
+const ships = {
+  ...shipsBase,
+  CLASS_LIMITS: shipsBase.CLASS_LIMITS ? clone(shipsBase.CLASS_LIMITS) : clone(naval.CLASS_LIMITS),
+};
+
+export const RULESETS = {
+  naval: { ...naval, CLASS_LIMITS: clone(naval.CLASS_LIMITS) },
+  ships,
+  ssc,
+};


### PR DESCRIPTION
## Summary
- clone the class limit tables when building the RULESETS registry so Naval and Ships configurations can diverge independently
- ensure the exported Naval ruleset also exposes its own copy of the class limits

## Testing
- `node - <<'NODE'
import { RULESETS } from './rulesets/index.js';
console.log(RULESETS.naval.CLASS_LIMITS === RULESETS.ships.CLASS_LIMITS);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68de04070f608321bb6a2d41e3d9d993