### PR TITLE
Add LR Naval Ships mechanical joint evaluation engine

### DIFF
--- a/data/lr_naval_ships_mech_joints.json
+++ b/data/lr_naval_ships_mech_joints.json
@@ -1,0 +1,622 @@
+{
+  "standard": "LR_NAVAL_SHIPS",
+  "version": "Vol2 Pt7 Ch1 §5.10 (Tables 1.5.3, 1.5.4)",
+  "systems": [
+    {
+      "id": "aircraft_vehicle_fuel_lt60",
+      "label_es": "Combustible aeronaves/vehículos (p.f. < 60°C)",
+      "label_en": "Aircraft & vehicle fuel oil (<60°C)",
+      "class_of_pipe_system": "dry",
+      "fire_test": "30min_dry",
+      "notes": [
+        2,
+        4,
+        3
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "vent_lines_flammable_lt60",
+      "label_es": "Respiraderos (p.f. < 60°C)",
+      "label_en": "Vent lines (<60°C)",
+      "class_of_pipe_system": "dry",
+      "fire_test": "30min_dry",
+      "notes": [
+        2,
+        3
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "aircraft_vehicle_fuel_gt60",
+      "label_es": "Combustible aeronaves/vehículos (p.f. > 60°C)",
+      "label_en": "Aircraft & vehicle fuel oil (>60°C)",
+      "class_of_pipe_system": "dry",
+      "fire_test": "30min_dry",
+      "notes": [
+        2,
+        4
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "machinery_fuel_oil_gt60",
+      "label_es": "Combustible maquinaria buque (p.f. > 60°C)",
+      "label_en": "Ship machinery fuel oil (>60°C)",
+      "class_of_pipe_system": "wet",
+      "fire_test": "30min_wet",
+      "notes": [
+        2,
+        3
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "lubricating_oil_gt60",
+      "label_es": "Aceite lubricante (p.f. > 60°C)",
+      "label_en": "Lubricating oil (>60°C)",
+      "class_of_pipe_system": "wet",
+      "fire_test": "30min_wet",
+      "notes": [
+        2,
+        3
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "hydraulic_oil_gt60",
+      "label_es": "Aceite hidráulico (p.f. > 60°C)",
+      "label_en": "Hydraulic oil (>60°C)",
+      "class_of_pipe_system": "wet",
+      "fire_test": "30min_wet",
+      "notes": [
+        2,
+        3
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "bilge_lines",
+      "label_es": "Líneas de achique",
+      "label_en": "Bilge lines",
+      "class_of_pipe_system": "dry/wet",
+      "fire_test": "8min_dry_plus_22min_wet",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "hp_sea_water_spray_npfilled",
+      "label_es": "Agua de mar alta presión / spray (no permanentemente llenas)",
+      "label_en": "HP sea water & spray (not permanently filled)",
+      "class_of_pipe_system": "dry/wet",
+      "fire_test": "8min_dry_plus_22min_wet",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "permanent_fire_mains_sprinkler",
+      "label_es": "Sistemas fijos llenos de agua (main/sprinkler)",
+      "label_en": "Permanent water-filled fire-extinguishing (fire main/sprinkler)",
+      "class_of_pipe_system": "wet",
+      "fire_test": "30min_wet",
+      "notes": [
+        3
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "non_permanent_fire_systems",
+      "label_es": "Sistemas no permanentes (espuma/drenchers/main)",
+      "label_en": "Non-permanent water-filled fire-extinguishing (foam/drencher/main)",
+      "class_of_pipe_system": "dry/wet",
+      "fire_test": "8min_dry_plus_22min_wet",
+      "notes": [
+        3
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      },
+      "extra": "FSS_Code_observed"
+    },
+    {
+      "id": "ballast_system",
+      "label_es": "Sistema de lastre",
+      "label_en": "Ballast system",
+      "class_of_pipe_system": "wet",
+      "fire_test": "8min_dry_plus_22min_wet",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "cooling_water_system",
+      "label_es": "Sistema de agua de refrigeración",
+      "label_en": "Cooling water system",
+      "class_of_pipe_system": "wet",
+      "fire_test": "8min_dry_plus_22min_wet",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "tank_cleaning_services",
+      "label_es": "Servicios de limpieza de tanques",
+      "label_en": "Tank cleaning services",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "sea_water_non_essential",
+      "label_es": "Sistemas no esenciales (agua de mar)",
+      "label_en": "Sea water non-essential systems",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "fresh_water_cooling_system",
+      "label_es": "Sistema de refrigeración (agua dulce)",
+      "label_en": "Fresh water cooling system",
+      "class_of_pipe_system": "wet",
+      "fire_test": "not_required",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "chilled_water_system",
+      "label_es": "Sistema de agua helada",
+      "label_en": "Chilled water system",
+      "class_of_pipe_system": "wet",
+      "fire_test": "30min_wet",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "condensate_return",
+      "label_es": "Retorno de condensado",
+      "label_en": "Condensate return",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "made_demin_water_system",
+      "label_es": "Sistema de agua preparada/desmineralizada",
+      "label_en": "Made & demineralised water system",
+      "class_of_pipe_system": "wet",
+      "fire_test": "not_required",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "fresh_water_ancillary",
+      "label_es": "Sistema auxiliar de agua dulce",
+      "label_en": "Fresh water ancillary system",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "deck_drains_internal",
+      "label_es": "Drenajes de cubierta (internos)",
+      "label_en": "Deck drains (internal)",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [
+        6
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "sanitary_drains",
+      "label_es": "Drenajes sanitarios",
+      "label_en": "Sanitary drains",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "scuppers_overboard",
+      "label_es": "Imbornales y descargas a mar",
+      "label_en": "Scuppers & discharge (overboard)",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": false
+      }
+    },
+    {
+      "id": "sounding_water_tanks_dry_spaces",
+      "label_es": "Sondas: tanques de agua / espacios secos",
+      "label_en": "Sounding: water tanks / dry spaces",
+      "class_of_pipe_system": "dry/wet",
+      "fire_test": "not_required",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "sounding_oil_tanks_gt60",
+      "label_es": "Sondas: tanques de aceite (p.f. > 60°C)",
+      "label_en": "Sounding: oil tanks (>60°C)",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [
+        2,
+        3
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "intakes_uptakes",
+      "label_es": "Entradas y salidas (intakes/uptakes)",
+      "label_en": "Intakes & uptakes",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [
+        7
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "hvac_trunking",
+      "label_es": "Conductos HVAC",
+      "label_en": "HVAC trunking",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [
+        7
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "hp_air_system",
+      "label_es": "Sistema de aire alta presión",
+      "label_en": "High pressure air system",
+      "class_of_pipe_system": "dry",
+      "fire_test": "30min_dry",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "mp_air_system",
+      "label_es": "Sistema de aire media presión",
+      "label_en": "Medium pressure air system",
+      "class_of_pipe_system": "dry",
+      "fire_test": "30min_dry",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "lp_air_system",
+      "label_es": "Sistema de aire baja presión",
+      "label_en": "Low pressure air system",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "service_air_nonessential",
+      "label_es": "Aire de servicio (no esencial)",
+      "label_en": "Service air (non-essential)",
+      "class_of_pipe_system": "dry",
+      "fire_test": "not_required",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "brine_system",
+      "label_es": "Sistema de salmuera",
+      "label_en": "Brine system",
+      "class_of_pipe_system": "wet",
+      "fire_test": "not_required",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    },
+    {
+      "id": "co2_system",
+      "label_es": "Sistema de CO₂",
+      "label_en": "CO₂ system",
+      "class_of_pipe_system": "dry",
+      "fire_test": "30min_dry",
+      "notes": [
+        1
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": false
+      }
+    },
+    {
+      "id": "nitrogen_system",
+      "label_es": "Sistema de nitrógeno",
+      "label_en": "Nitrogen system",
+      "class_of_pipe_system": "dry",
+      "fire_test": "30min_dry",
+      "notes": [],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": false
+      }
+    },
+    {
+      "id": "steam",
+      "label_es": "Vapor",
+      "label_en": "Steam",
+      "class_of_pipe_system": "see_note_5",
+      "fire_test": "not_required",
+      "notes": [
+        5
+      ],
+      "allowed_joints": {
+        "pipe_unions": true,
+        "compression_couplings": true,
+        "slip_on_joints": true
+      }
+    }
+  ],
+  "pipe_class_rules": [
+    {
+      "joint": "pipe_union_welded_brazed",
+      "class": [
+        "I",
+        "II",
+        "III"
+      ],
+      "od_max_mm": 60.3
+    },
+    {
+      "joint": "compression_swage",
+      "class": [
+        "III"
+      ]
+    },
+    {
+      "joint": "compression_bite",
+      "class": [
+        "I",
+        "II",
+        "III"
+      ],
+      "od_max_mm": 60.3
+    },
+    {
+      "joint": "compression_typical",
+      "class": [
+        "I",
+        "II",
+        "III"
+      ],
+      "od_max_mm": 60.3
+    },
+    {
+      "joint": "compression_flared",
+      "class": [
+        "I",
+        "II",
+        "III"
+      ],
+      "od_max_mm": 60.3
+    },
+    {
+      "joint": "compression_press",
+      "class": [
+        "III"
+      ]
+    },
+    {
+      "joint": "slip_on_machine_grooved",
+      "class": [
+        "I",
+        "II",
+        "III"
+      ]
+    },
+    {
+      "joint": "slip_on_grip",
+      "class": [
+        "II",
+        "III"
+      ]
+    },
+    {
+      "joint": "slip_on_slip_type",
+      "class": [
+        "II",
+        "III"
+      ]
+    }
+  ],
+  "notes": {
+    "1": {
+      "type": "catA_fire_resistant_if_deteriorates_and_material_for_bilge_main",
+      "catA_requires_fire_resistant": true,
+      "bilge_main_materials": [
+        "steel",
+        "CuNi",
+        "equivalent"
+      ]
+    },
+    "2": {
+      "type": "no_slip_on_in_catA_munitions_accommodation",
+      "prohibit_spaces": [
+        "machinery_cat_A",
+        "munitions_store",
+        "accommodation"
+      ],
+      "allow_other_machinery_if_visible_accessible": true
+    },
+    "3": {
+      "type": "fire_resistant_except_open_deck_low_fire_risk",
+      "exception": {
+        "space": "open_deck_low_risk_SOLAS_9_2_3_3_2_2_10"
+      }
+    },
+    "4": {
+      "type": "fire_resistant_required"
+    },
+    "5": {
+      "type": "restrained_slip_on_steam_open_deck_tankers_le_10bar",
+      "space": "open_deck",
+      "ship_types": [
+        "oil_tanker",
+        "chemical_tanker"
+      ],
+      "max_pressure_bar": 10
+    },
+    "6": {
+      "type": "only_above_limit_of_watertight_integrity"
+    },
+    "7": {
+      "type": "hvac_trunking_intakes_uptakes_defer",
+      "message": "HVAC/uptakes/intakes: ver secciones específicas de las Reglas."
+    }
+  }
+}

--- a/data/lr_ships_mech_joints.ts
+++ b/data/lr_ships_mech_joints.ts
@@ -41,6 +41,8 @@ export type Joint =
   | "compression_couplings"
   | "slip_on_joints"
   | "pipe_union_welded_brazed"
+  | "compression_swage"
+  | "compression_typical"
   | "compression_bite"
   | "compression_flared"
   | "compression_press"

--- a/dist/data/lr_naval_ships_mech_joints.json
+++ b/dist/data/lr_naval_ships_mech_joints.json
@@ -1,0 +1,622 @@
+{
+    "standard": "LR_NAVAL_SHIPS",
+    "version": "Vol2 Pt7 Ch1 §5.10 (Tables 1.5.3, 1.5.4)",
+    "systems": [
+        {
+            "id": "aircraft_vehicle_fuel_lt60",
+            "label_es": "Combustible aeronaves/vehículos (p.f. < 60°C)",
+            "label_en": "Aircraft & vehicle fuel oil (<60°C)",
+            "class_of_pipe_system": "dry",
+            "fire_test": "30min_dry",
+            "notes": [
+                2,
+                4,
+                3
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "vent_lines_flammable_lt60",
+            "label_es": "Respiraderos (p.f. < 60°C)",
+            "label_en": "Vent lines (<60°C)",
+            "class_of_pipe_system": "dry",
+            "fire_test": "30min_dry",
+            "notes": [
+                2,
+                3
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "aircraft_vehicle_fuel_gt60",
+            "label_es": "Combustible aeronaves/vehículos (p.f. > 60°C)",
+            "label_en": "Aircraft & vehicle fuel oil (>60°C)",
+            "class_of_pipe_system": "dry",
+            "fire_test": "30min_dry",
+            "notes": [
+                2,
+                4
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "machinery_fuel_oil_gt60",
+            "label_es": "Combustible maquinaria buque (p.f. > 60°C)",
+            "label_en": "Ship machinery fuel oil (>60°C)",
+            "class_of_pipe_system": "wet",
+            "fire_test": "30min_wet",
+            "notes": [
+                2,
+                3
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "lubricating_oil_gt60",
+            "label_es": "Aceite lubricante (p.f. > 60°C)",
+            "label_en": "Lubricating oil (>60°C)",
+            "class_of_pipe_system": "wet",
+            "fire_test": "30min_wet",
+            "notes": [
+                2,
+                3
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "hydraulic_oil_gt60",
+            "label_es": "Aceite hidráulico (p.f. > 60°C)",
+            "label_en": "Hydraulic oil (>60°C)",
+            "class_of_pipe_system": "wet",
+            "fire_test": "30min_wet",
+            "notes": [
+                2,
+                3
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "bilge_lines",
+            "label_es": "Líneas de achique",
+            "label_en": "Bilge lines",
+            "class_of_pipe_system": "dry/wet",
+            "fire_test": "8min_dry_plus_22min_wet",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "hp_sea_water_spray_npfilled",
+            "label_es": "Agua de mar alta presión / spray (no permanentemente llenas)",
+            "label_en": "HP sea water & spray (not permanently filled)",
+            "class_of_pipe_system": "dry/wet",
+            "fire_test": "8min_dry_plus_22min_wet",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "permanent_fire_mains_sprinkler",
+            "label_es": "Sistemas fijos llenos de agua (main/sprinkler)",
+            "label_en": "Permanent water-filled fire-extinguishing (fire main/sprinkler)",
+            "class_of_pipe_system": "wet",
+            "fire_test": "30min_wet",
+            "notes": [
+                3
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "non_permanent_fire_systems",
+            "label_es": "Sistemas no permanentes (espuma/drenchers/main)",
+            "label_en": "Non-permanent water-filled fire-extinguishing (foam/drencher/main)",
+            "class_of_pipe_system": "dry/wet",
+            "fire_test": "8min_dry_plus_22min_wet",
+            "notes": [
+                3
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            },
+            "extra": "FSS_Code_observed"
+        },
+        {
+            "id": "ballast_system",
+            "label_es": "Sistema de lastre",
+            "label_en": "Ballast system",
+            "class_of_pipe_system": "wet",
+            "fire_test": "8min_dry_plus_22min_wet",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "cooling_water_system",
+            "label_es": "Sistema de agua de refrigeración",
+            "label_en": "Cooling water system",
+            "class_of_pipe_system": "wet",
+            "fire_test": "8min_dry_plus_22min_wet",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "tank_cleaning_services",
+            "label_es": "Servicios de limpieza de tanques",
+            "label_en": "Tank cleaning services",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "sea_water_non_essential",
+            "label_es": "Sistemas no esenciales (agua de mar)",
+            "label_en": "Sea water non-essential systems",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "fresh_water_cooling_system",
+            "label_es": "Sistema de refrigeración (agua dulce)",
+            "label_en": "Fresh water cooling system",
+            "class_of_pipe_system": "wet",
+            "fire_test": "not_required",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "chilled_water_system",
+            "label_es": "Sistema de agua helada",
+            "label_en": "Chilled water system",
+            "class_of_pipe_system": "wet",
+            "fire_test": "30min_wet",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "condensate_return",
+            "label_es": "Retorno de condensado",
+            "label_en": "Condensate return",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "made_demin_water_system",
+            "label_es": "Sistema de agua preparada/desmineralizada",
+            "label_en": "Made & demineralised water system",
+            "class_of_pipe_system": "wet",
+            "fire_test": "not_required",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "fresh_water_ancillary",
+            "label_es": "Sistema auxiliar de agua dulce",
+            "label_en": "Fresh water ancillary system",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "deck_drains_internal",
+            "label_es": "Drenajes de cubierta (internos)",
+            "label_en": "Deck drains (internal)",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [
+                6
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "sanitary_drains",
+            "label_es": "Drenajes sanitarios",
+            "label_en": "Sanitary drains",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "scuppers_overboard",
+            "label_es": "Imbornales y descargas a mar",
+            "label_en": "Scuppers & discharge (overboard)",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": false
+            }
+        },
+        {
+            "id": "sounding_water_tanks_dry_spaces",
+            "label_es": "Sondas: tanques de agua / espacios secos",
+            "label_en": "Sounding: water tanks / dry spaces",
+            "class_of_pipe_system": "dry/wet",
+            "fire_test": "not_required",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "sounding_oil_tanks_gt60",
+            "label_es": "Sondas: tanques de aceite (p.f. > 60°C)",
+            "label_en": "Sounding: oil tanks (>60°C)",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [
+                2,
+                3
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "intakes_uptakes",
+            "label_es": "Entradas y salidas (intakes/uptakes)",
+            "label_en": "Intakes & uptakes",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [
+                7
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "hvac_trunking",
+            "label_es": "Conductos HVAC",
+            "label_en": "HVAC trunking",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [
+                7
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "hp_air_system",
+            "label_es": "Sistema de aire alta presión",
+            "label_en": "High pressure air system",
+            "class_of_pipe_system": "dry",
+            "fire_test": "30min_dry",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "mp_air_system",
+            "label_es": "Sistema de aire media presión",
+            "label_en": "Medium pressure air system",
+            "class_of_pipe_system": "dry",
+            "fire_test": "30min_dry",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "lp_air_system",
+            "label_es": "Sistema de aire baja presión",
+            "label_en": "Low pressure air system",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "service_air_nonessential",
+            "label_es": "Aire de servicio (no esencial)",
+            "label_en": "Service air (non-essential)",
+            "class_of_pipe_system": "dry",
+            "fire_test": "not_required",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "brine_system",
+            "label_es": "Sistema de salmuera",
+            "label_en": "Brine system",
+            "class_of_pipe_system": "wet",
+            "fire_test": "not_required",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        },
+        {
+            "id": "co2_system",
+            "label_es": "Sistema de CO₂",
+            "label_en": "CO₂ system",
+            "class_of_pipe_system": "dry",
+            "fire_test": "30min_dry",
+            "notes": [
+                1
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": false
+            }
+        },
+        {
+            "id": "nitrogen_system",
+            "label_es": "Sistema de nitrógeno",
+            "label_en": "Nitrogen system",
+            "class_of_pipe_system": "dry",
+            "fire_test": "30min_dry",
+            "notes": [],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": false
+            }
+        },
+        {
+            "id": "steam",
+            "label_es": "Vapor",
+            "label_en": "Steam",
+            "class_of_pipe_system": "see_note_5",
+            "fire_test": "not_required",
+            "notes": [
+                5
+            ],
+            "allowed_joints": {
+                "pipe_unions": true,
+                "compression_couplings": true,
+                "slip_on_joints": true
+            }
+        }
+    ],
+    "pipe_class_rules": [
+        {
+            "joint": "pipe_union_welded_brazed",
+            "class": [
+                "I",
+                "II",
+                "III"
+            ],
+            "od_max_mm": 60.3
+        },
+        {
+            "joint": "compression_swage",
+            "class": [
+                "III"
+            ]
+        },
+        {
+            "joint": "compression_bite",
+            "class": [
+                "I",
+                "II",
+                "III"
+            ],
+            "od_max_mm": 60.3
+        },
+        {
+            "joint": "compression_typical",
+            "class": [
+                "I",
+                "II",
+                "III"
+            ],
+            "od_max_mm": 60.3
+        },
+        {
+            "joint": "compression_flared",
+            "class": [
+                "I",
+                "II",
+                "III"
+            ],
+            "od_max_mm": 60.3
+        },
+        {
+            "joint": "compression_press",
+            "class": [
+                "III"
+            ]
+        },
+        {
+            "joint": "slip_on_machine_grooved",
+            "class": [
+                "I",
+                "II",
+                "III"
+            ]
+        },
+        {
+            "joint": "slip_on_grip",
+            "class": [
+                "II",
+                "III"
+            ]
+        },
+        {
+            "joint": "slip_on_slip_type",
+            "class": [
+                "II",
+                "III"
+            ]
+        }
+    ],
+    "notes": {
+        "1": {
+            "type": "catA_fire_resistant_if_deteriorates_and_material_for_bilge_main",
+            "catA_requires_fire_resistant": true,
+            "bilge_main_materials": [
+                "steel",
+                "CuNi",
+                "equivalent"
+            ]
+        },
+        "2": {
+            "type": "no_slip_on_in_catA_munitions_accommodation",
+            "prohibit_spaces": [
+                "machinery_cat_A",
+                "munitions_store",
+                "accommodation"
+            ],
+            "allow_other_machinery_if_visible_accessible": true
+        },
+        "3": {
+            "type": "fire_resistant_except_open_deck_low_fire_risk",
+            "exception": {
+                "space": "open_deck_low_risk_SOLAS_9_2_3_3_2_2_10"
+            }
+        },
+        "4": {
+            "type": "fire_resistant_required"
+        },
+        "5": {
+            "type": "restrained_slip_on_steam_open_deck_tankers_le_10bar",
+            "space": "open_deck",
+            "ship_types": [
+                "oil_tanker",
+                "chemical_tanker"
+            ],
+            "max_pressure_bar": 10
+        },
+        "6": {
+            "type": "only_above_limit_of_watertight_integrity"
+        },
+        "7": {
+            "type": "hvac_trunking_intakes_uptakes_defer",
+            "message": "HVAC/uptakes/intakes: ver secciones específicas de las Reglas."
+        }
+    }
+}

--- a/dist/engine/evaluateLRNavalShips.js
+++ b/dist/engine/evaluateLRNavalShips.js
@@ -1,0 +1,294 @@
+import dataset from "../data/lr_naval_ships_mech_joints.json";
+const normReference = "LR Naval Ships Vol2 Pt7 Ch1 §5.10, Tablas 1.5.3–1.5.4";
+const FIRE_TEST_LABELS = {
+    "30min_dry": "Ensayo de fuego: 30 min seco",
+    "30min_wet": "Ensayo de fuego: 30 min húmedo",
+    "8min_dry_plus_22min_wet": "Ensayo de fuego: 8 min seco + 22 min húmedo",
+};
+const NOTE1_FIRE_CHIP = "Tipo resistente al fuego si componentes se deterioran en incendio (Cat. A)";
+const NOTE1_BILGE_MATERIAL_CHIP = "Material acople bilge main: acero/CuNi/equiv.";
+const NOTE2_LOCATION_CHIP = "Ubicación visible y accesible";
+const NOTE3_FIRE_CHIP = "Tipo resistente al fuego";
+const NOTE4_FIRE_CHIP = "Tipo resistente al fuego";
+const NOTE5_STEAM_CHIP = "Restringido a cubierta expuesta ≤10 bar (vapor, petroleros/quimiqueros)";
+const NOTE6_WLI_CHIP = "Solo sobre Límite de Integridad Estanca (WLI)";
+const NOTE7_INFO_CHIP = "HVAC/intakes: ver secciones específicas de las Reglas";
+const SLIP_TYPE_WARNING = "No como medio principal (slip-type)";
+const TAILORING_CHIP_PREFIX = "Tailoring Doc: validar";
+const db = dataset;
+export function evaluateLRNavalShips(ctx, datasetOverride = db) {
+    const trace = [];
+    const sys = datasetOverride.systems.find((s) => s.id === ctx.systemId);
+    if (!sys) {
+        return forbid(ctx, trace, "Sistema no reconocido");
+    }
+    const jointGroup = groupOf(ctx.joint);
+    if (!jointGroup) {
+        return forbid(ctx, trace, "Tipo de junta desconocido");
+    }
+    const allowedByRow = Boolean(sys.allowed_joints[jointGroup]);
+    trace.push(`Tabla 1.5.3 (${sys.label_es}): ${allowedByRow ? "+" : "–"} para ${describeJointGroup(jointGroup)}; clase '${sys.class_of_pipe_system}'.`);
+    if (!allowedByRow) {
+        return forbid(ctx, trace, "Tabla 1.5.3: '-' para este tipo de junta");
+    }
+    const classCheck = passClassOD(ctx.joint, ctx.pipeClass, ctx.od_mm, datasetOverride);
+    if (!classCheck.ok) {
+        if (classCheck.reason === "missing_inputs") {
+            return forbid(ctx, trace, "Falta clase/OD (Tabla 1.5.4)");
+        }
+        return forbid(ctx, trace, "Tabla 1.5.4: límite de clase/OD", classCheck.detail);
+    }
+    if (classCheck.detail) {
+        trace.push(classCheck.detail);
+    }
+    let status = sys.fire_test !== "not_required" ? "conditional" : "allowed";
+    let reason;
+    const conditions = [];
+    let skipGeneralClauses = false;
+    const addCondition = (msg, forceConditional = true) => {
+        if (!conditions.includes(msg)) {
+            conditions.push(msg);
+        }
+        if (forceConditional && status !== "forbidden") {
+            status = "conditional";
+        }
+    };
+    const addTrace = (msg) => {
+        trace.push(msg);
+    };
+    if (sys.fire_test !== "not_required") {
+        const label = FIRE_TEST_LABELS[sys.fire_test] ?? sys.fire_test;
+        addCondition(label, true);
+        addTrace(`Tabla 1.5.3: Ensayo base ${label}.`);
+    }
+    for (const noteId of sys.notes) {
+        if (reason)
+            break;
+        const note = datasetOverride.notes[String(noteId)];
+        if (!note)
+            continue;
+        switch (note.type) {
+            case "catA_fire_resistant_if_deteriorates_and_material_for_bilge_main": {
+                if (ctx.space === "machinery_cat_A" && note.catA_requires_fire_resistant) {
+                    addCondition(NOTE1_FIRE_CHIP);
+                    addTrace(`Nota ${noteId}: En Cat. A usar juntas resistentes al fuego si hay componentes que se deterioran.`);
+                }
+                if (ctx.space === "machinery_cat_A" && sys.id === "bilge_lines") {
+                    addCondition(NOTE1_BILGE_MATERIAL_CHIP);
+                    addTrace(`Nota ${noteId}: Acoples del bilge main en Cat. A deben ser acero/CuNi/equiv.`);
+                }
+                break;
+            }
+            case "no_slip_on_in_catA_munitions_accommodation": {
+                if (isSlipOn(ctx.joint)) {
+                    if (note.prohibit_spaces.includes(ctx.space)) {
+                        addTrace(`Nota ${noteId}: Slip-on prohibidas en ${ctx.space}.`);
+                        reason = `Nota ${noteId}: slip-on no aceptadas en este espacio`;
+                    }
+                    else if (ctx.space === "other_machinery" &&
+                        note.allow_other_machinery_if_visible_accessible &&
+                        ctx.location !== "visible_accessible") {
+                        addCondition(NOTE2_LOCATION_CHIP);
+                        addTrace(`Nota ${noteId}: En otros espacios de maquinaria deben quedar visibles y accesibles.`);
+                    }
+                }
+                break;
+            }
+            case "fire_resistant_except_open_deck_low_fire_risk": {
+                if (ctx.space !== note.exception.space) {
+                    addCondition(NOTE3_FIRE_CHIP);
+                    addTrace(`Nota ${noteId}: Exigir tipo resistente al fuego salvo en cubierta abierta de bajo riesgo.`);
+                }
+                break;
+            }
+            case "fire_resistant_required": {
+                addCondition(NOTE4_FIRE_CHIP);
+                addTrace(`Nota ${noteId}: Requiere tipo resistente al fuego.`);
+                break;
+            }
+            case "restrained_slip_on_steam_open_deck_tankers_le_10bar": {
+                if (isSlipOn(ctx.joint)) {
+                    const okPressure = (ctx.designPressure_bar ?? Number.POSITIVE_INFINITY) <= note.max_pressure_bar;
+                    const okLocation = ctx.space === note.space;
+                    const okShipType = note.ship_types.includes(ctx.shipType ?? "other");
+                    const isRestrained = ctx.joint === "slip_on_machine_grooved";
+                    if (okPressure && okLocation && okShipType && isRestrained) {
+                        addCondition(NOTE5_STEAM_CHIP, false);
+                        addTrace(`Nota ${noteId}: Slip-on restringida permitida en cubierta expuesta para vapor ≤ ${note.max_pressure_bar} bar en petroleros/quimiqueros.`);
+                    }
+                    else {
+                        addTrace(`Nota ${noteId}: Condiciones para restrained slip-on en vapor no satisfechas.`);
+                        reason =
+                            "Nota 5: solo se permiten restrained slip-on en cubierta expuesta de petroleros/quimiqueros con P ≤ 10 bar";
+                    }
+                }
+                break;
+            }
+            case "only_above_limit_of_watertight_integrity": {
+                if (ctx.aboveLimitOfWatertightIntegrity === false) {
+                    addTrace(`Nota ${noteId}: Aplicable solo sobre el límite de integridad estanca.`);
+                    addCondition(NOTE6_WLI_CHIP);
+                    reason = "Nota 6: solo permitido sobre el Límite de Integridad Estanca";
+                }
+                else if (ctx.aboveLimitOfWatertightIntegrity !== undefined) {
+                    addCondition(NOTE6_WLI_CHIP, false);
+                    addTrace(`Nota ${noteId}: Confirmado sobre el límite de integridad estanca.`);
+                }
+                break;
+            }
+            case "hvac_trunking_intakes_uptakes_defer": {
+                addCondition(NOTE7_INFO_CHIP, false);
+                addTrace(`Nota ${noteId}: ${note.message}`);
+                skipGeneralClauses = true;
+                break;
+            }
+        }
+    }
+    if (reason) {
+        return forbid(ctx, trace, reason, undefined, conditions);
+    }
+    if (!skipGeneralClauses) {
+        const generalReason = applyGeneralClauses(ctx, sys, addCondition, addTrace);
+        if (generalReason) {
+            return forbid(ctx, trace, generalReason, undefined, conditions);
+        }
+    }
+    if (ctx.tailoring && (ctx.tailoring.shock || ctx.tailoring.fire || ctx.tailoring.watertight)) {
+        const requirements = [
+            ctx.tailoring.shock ? "Shock" : null,
+            ctx.tailoring.fire ? "Fire" : null,
+            ctx.tailoring.watertight ? "WT" : null,
+        ].filter(Boolean);
+        addCondition(`${TAILORING_CHIP_PREFIX} ${requirements.join("/") || "Shock/Fire/WT"}`);
+        addTrace("§5.10.2: Verificar requisitos de Tailoring Doc (autoridad naval).");
+    }
+    return {
+        status,
+        conditions,
+        normRef: normReference,
+        systemId: sys.id,
+        joint: ctx.joint,
+        pipeClass: ctx.pipeClass,
+        od_mm: ctx.od_mm,
+        designPressure_bar: ctx.designPressure_bar,
+        trace,
+    };
+}
+function applyGeneralClauses(ctx, sys, addCondition, addTrace) {
+    if (ctx.isSectionDirectlyConnectedToShipSide && ctx.aboveLimitOfWatertightIntegrity === false) {
+        addTrace("§5.10.6: Tramo conectado al costado bajo WLI → juntas mecánicas prohibidas.");
+        return "§5.10.6: no se permiten juntas si el tramo conectado al costado está bajo el WLI";
+    }
+    if (ctx.space === "tank" && (ctx.lineType === "fuel_oil" || ctx.lineType === "thermal_oil")) {
+        addTrace("§5.10.6: Tanques con fluidos inflamables → juntas mecánicas prohibidas.");
+        return "§5.10.6: juntas prohibidas en tanques con fluidos inflamables";
+    }
+    if (isSlipOn(ctx.joint)) {
+        if (ctx.accessibility === "not_easy") {
+            addTrace("§5.10.9: Slip-on prohibidas en ubicaciones de difícil acceso.");
+            return "§5.10.9: slip-on no permitidas si no hay acceso fácil";
+        }
+        if (ctx.space === "tank") {
+            if (ctx.mediumInPipeSameAsTank === true) {
+                addTrace("§5.10.9: Slip-on dentro de tanques solo si el medio es el mismo.");
+            }
+            else {
+                addTrace("§5.10.9: Slip-on en tanques con medio diferente están prohibidas.");
+                return "§5.10.9: slip-on solo dentro de tanques con el mismo medio";
+            }
+        }
+        if (["cargo_hold", "cofferdam", "void"].includes(ctx.space)) {
+            addTrace("§5.10.9: Slip-on prohibidas en espacios no accesibles.");
+            return "§5.10.9: slip-on prohibidas en bodegas, cofferdams o voids";
+        }
+    }
+    if (ctx.joint === "slip_on_slip_type") {
+        if (ctx.mainMeansOfConnection) {
+            addCondition(SLIP_TYPE_WARNING, false);
+            addTrace("§5.10.10: Slip type no debe ser medio principal de conexión.");
+            return "§5.10.10: slip type no puede usarse como medio principal";
+        }
+        addCondition(SLIP_TYPE_WARNING, false);
+        addTrace("§5.10.10: Recordatorio – slip type solo para compensación axial.");
+    }
+    return null;
+}
+function groupOf(joint) {
+    if (joint === "pipe_unions" || joint === "compression_couplings" || joint === "slip_on_joints") {
+        return joint;
+    }
+    if (joint === "pipe_union_welded_brazed")
+        return "pipe_unions";
+    if (joint === "compression_swage" ||
+        joint === "compression_typical" ||
+        joint === "compression_bite" ||
+        joint === "compression_flared" ||
+        joint === "compression_press") {
+        return "compression_couplings";
+    }
+    if (joint === "slip_on_machine_grooved" ||
+        joint === "slip_on_grip" ||
+        joint === "slip_on_slip_type") {
+        return "slip_on_joints";
+    }
+    return null;
+}
+function isSlipOn(joint) {
+    return groupOf(joint) === "slip_on_joints";
+}
+function describeJointGroup(group) {
+    switch (group) {
+        case "pipe_unions":
+            return "pipe unions";
+        case "compression_couplings":
+            return "compression couplings";
+        case "slip_on_joints":
+            return "slip-on joints";
+    }
+}
+function passClassOD(joint, pipeClass, odMM, datasetOverride) {
+    const rules = datasetOverride.pipe_class_rules.filter((rule) => rule.joint === joint);
+    const effectiveRules = rules.length
+        ? rules
+        : datasetOverride.pipe_class_rules.filter((rule) => groupOf(rule.joint) === joint);
+    if (!effectiveRules.length) {
+        return { ok: true };
+    }
+    if (!pipeClass) {
+        return { ok: false, reason: "missing_inputs" };
+    }
+    const match = effectiveRules.find((rule) => rule.class.includes(pipeClass));
+    if (!match) {
+        return { ok: false, reason: "limit" };
+    }
+    if (match.od_max_mm != null) {
+        if (typeof odMM !== "number") {
+            return { ok: false, reason: "missing_inputs" };
+        }
+        if (odMM > match.od_max_mm + 1e-6) {
+            return { ok: false, reason: "limit" };
+        }
+    }
+    const detail = match.od_max_mm != null
+        ? `Tabla 1.5.4: Clase ${pipeClass} con OD ≤ ${match.od_max_mm} mm`
+        : `Tabla 1.5.4: Clase ${pipeClass}`;
+    return { ok: true, detail };
+}
+function forbid(ctx, trace, message, detail, conditions) {
+    if (detail) {
+        trace.push(detail);
+    }
+    return {
+        status: "forbidden",
+        conditions: conditions ? [...conditions] : [],
+        normRef: normReference,
+        reason: message,
+        systemId: ctx.systemId,
+        joint: ctx.joint,
+        pipeClass: ctx.pipeClass,
+        od_mm: ctx.od_mm,
+        designPressure_bar: ctx.designPressure_bar,
+        trace: [...trace],
+    };
+}
+export default evaluateLRNavalShips;

--- a/dist/engine/lrShips.js
+++ b/dist/engine/lrShips.js
@@ -172,7 +172,11 @@ function groupOf(joint) {
     }
     if (joint === "pipe_union_welded_brazed")
         return "pipe_unions";
-    if (joint === "compression_bite" || joint === "compression_flared" || joint === "compression_press") {
+    if (joint === "compression_swage" ||
+        joint === "compression_typical" ||
+        joint === "compression_bite" ||
+        joint === "compression_flared" ||
+        joint === "compression_press") {
         return "compression_couplings";
     }
     if (joint === "slip_on_machine_grooved" ||

--- a/engine/evaluateLRNavalShips.ts
+++ b/engine/evaluateLRNavalShips.ts
@@ -1,0 +1,462 @@
+import dataset from "../data/lr_naval_ships_mech_joints.json";
+import type { Joint, PipeClass } from "../data/lr_ships_mech_joints.js";
+
+export type Space =
+  | "machinery_cat_A"
+  | "other_machinery"
+  | "accommodation"
+  | "munitions_store"
+  | "pump_room"
+  | "open_deck"
+  | "open_deck_low_risk_SOLAS_9_2_3_3_2_2_10"
+  | "cargo_hold"
+  | "tank"
+  | "cofferdam"
+  | "void"
+  | "intake_uptake";
+
+export type ShipType = "naval" | "oil_tanker" | "chemical_tanker" | "other";
+
+export interface LRNavalShipsContext {
+  systemId: string;
+  space: Space;
+  joint: Joint;
+  pipeClass?: PipeClass;
+  od_mm?: number;
+  designPressure_bar?: number;
+  isSectionDirectlyConnectedToShipSide?: boolean;
+  aboveLimitOfWatertightIntegrity?: boolean;
+  accessibility?: "easy" | "not_easy";
+  location?: "visible_accessible" | "normal";
+  mediumInPipeSameAsTank?: boolean;
+  lineType?: "fuel_oil" | "thermal_oil" | "other";
+  shipType?: ShipType;
+  tailoring?: { shock?: boolean; fire?: boolean; watertight?: boolean };
+  mainMeansOfConnection?: boolean;
+}
+
+export interface LRNavalShipsEvaluation {
+  status: "allowed" | "conditional" | "forbidden";
+  conditions: string[];
+  normRef: string;
+  reason?: string;
+  systemId: string;
+  joint: Joint;
+  pipeClass?: PipeClass;
+  od_mm?: number;
+  designPressure_bar?: number;
+  trace: string[];
+}
+
+const normReference = "LR Naval Ships Vol2 Pt7 Ch1 §5.10, Tablas 1.5.3–1.5.4";
+
+const FIRE_TEST_LABELS: Record<string, string> = {
+  "30min_dry": "Ensayo de fuego: 30 min seco",
+  "30min_wet": "Ensayo de fuego: 30 min húmedo",
+  "8min_dry_plus_22min_wet": "Ensayo de fuego: 8 min seco + 22 min húmedo",
+};
+
+const NOTE1_FIRE_CHIP =
+  "Tipo resistente al fuego si componentes se deterioran en incendio (Cat. A)";
+const NOTE1_BILGE_MATERIAL_CHIP = "Material acople bilge main: acero/CuNi/equiv.";
+const NOTE2_LOCATION_CHIP = "Ubicación visible y accesible";
+const NOTE3_FIRE_CHIP = "Tipo resistente al fuego";
+const NOTE4_FIRE_CHIP = "Tipo resistente al fuego";
+const NOTE5_STEAM_CHIP =
+  "Restringido a cubierta expuesta ≤10 bar (vapor, petroleros/quimiqueros)";
+const NOTE6_WLI_CHIP = "Solo sobre Límite de Integridad Estanca (WLI)";
+const NOTE7_INFO_CHIP = "HVAC/intakes: ver secciones específicas de las Reglas";
+const SLIP_TYPE_WARNING = "No como medio principal (slip-type)";
+const TAILORING_CHIP_PREFIX = "Tailoring Doc: validar";
+
+type JointGroup = "pipe_unions" | "compression_couplings" | "slip_on_joints";
+
+type NavalSystem = {
+  id: string;
+  label_es: string;
+  label_en: string;
+  class_of_pipe_system: string;
+  fire_test: "30min_dry" | "30min_wet" | "8min_dry_plus_22min_wet" | "not_required";
+  notes: number[];
+  extra?: string;
+  allowed_joints: Partial<Record<JointGroup, boolean>>;
+};
+
+type NavalNote =
+  | {
+      type: "catA_fire_resistant_if_deteriorates_and_material_for_bilge_main";
+      catA_requires_fire_resistant: boolean;
+      bilge_main_materials: string[];
+    }
+  | {
+      type: "no_slip_on_in_catA_munitions_accommodation";
+      prohibit_spaces: Space[];
+      allow_other_machinery_if_visible_accessible: boolean;
+    }
+  | {
+      type: "fire_resistant_except_open_deck_low_fire_risk";
+      exception: { space: Space };
+    }
+  | { type: "fire_resistant_required" }
+  | {
+      type: "restrained_slip_on_steam_open_deck_tankers_le_10bar";
+      space: "open_deck";
+      ship_types: ShipType[];
+      max_pressure_bar: number;
+    }
+  | { type: "only_above_limit_of_watertight_integrity" }
+  | { type: "hvac_trunking_intakes_uptakes_defer"; message: string };
+
+type NavalPipeClassRule = {
+  joint: Joint;
+  class: PipeClass[];
+  od_max_mm?: number;
+};
+
+type NavalDataset = {
+  standard: "LR_NAVAL_SHIPS";
+  version: string;
+  systems: NavalSystem[];
+  pipe_class_rules: NavalPipeClassRule[];
+  notes: Record<string, NavalNote>;
+};
+
+const db = dataset as NavalDataset;
+
+type Status = "allowed" | "conditional" | "forbidden";
+
+type ClassCheckResult =
+  | { ok: true; detail?: string }
+  | { ok: false; reason: "missing_inputs" | "limit"; detail?: string };
+
+export function evaluateLRNavalShips(
+  ctx: LRNavalShipsContext,
+  datasetOverride: NavalDataset = db
+): LRNavalShipsEvaluation {
+  const trace: string[] = [];
+  const sys = datasetOverride.systems.find((s) => s.id === ctx.systemId);
+  if (!sys) {
+    return forbid(ctx, trace, "Sistema no reconocido");
+  }
+
+  const jointGroup = groupOf(ctx.joint);
+  if (!jointGroup) {
+    return forbid(ctx, trace, "Tipo de junta desconocido");
+  }
+
+  const allowedByRow = Boolean(sys.allowed_joints[jointGroup]);
+  trace.push(
+    `Tabla 1.5.3 (${sys.label_es}): ${allowedByRow ? "+" : "–"} para ${describeJointGroup(
+      jointGroup
+    )}; clase '${sys.class_of_pipe_system}'.`
+  );
+  if (!allowedByRow) {
+    return forbid(ctx, trace, "Tabla 1.5.3: '-' para este tipo de junta");
+  }
+
+  const classCheck = passClassOD(ctx.joint, ctx.pipeClass, ctx.od_mm, datasetOverride);
+  if (!classCheck.ok) {
+    if (classCheck.reason === "missing_inputs") {
+      return forbid(ctx, trace, "Falta clase/OD (Tabla 1.5.4)");
+    }
+    return forbid(ctx, trace, "Tabla 1.5.4: límite de clase/OD", classCheck.detail);
+  }
+  if (classCheck.detail) {
+    trace.push(classCheck.detail);
+  }
+
+  let status: Status = sys.fire_test !== "not_required" ? "conditional" : "allowed";
+  let reason: string | undefined;
+  const conditions: string[] = [];
+  let skipGeneralClauses = false;
+
+  const addCondition = (msg: string, forceConditional = true) => {
+    if (!conditions.includes(msg)) {
+      conditions.push(msg);
+    }
+    if (forceConditional && status !== "forbidden") {
+      status = "conditional";
+    }
+  };
+
+  const addTrace = (msg: string) => {
+    trace.push(msg);
+  };
+
+  if (sys.fire_test !== "not_required") {
+    const label = FIRE_TEST_LABELS[sys.fire_test] ?? sys.fire_test;
+    addCondition(label, true);
+    addTrace(`Tabla 1.5.3: Ensayo base ${label}.`);
+  }
+
+  for (const noteId of sys.notes) {
+    if (reason) break;
+    const note = datasetOverride.notes[String(noteId)];
+    if (!note) continue;
+    switch (note.type) {
+      case "catA_fire_resistant_if_deteriorates_and_material_for_bilge_main": {
+        if (ctx.space === "machinery_cat_A" && note.catA_requires_fire_resistant) {
+          addCondition(NOTE1_FIRE_CHIP);
+          addTrace(`Nota ${noteId}: En Cat. A usar juntas resistentes al fuego si hay componentes que se deterioran.`);
+        }
+        if (ctx.space === "machinery_cat_A" && sys.id === "bilge_lines") {
+          addCondition(NOTE1_BILGE_MATERIAL_CHIP);
+          addTrace(`Nota ${noteId}: Acoples del bilge main en Cat. A deben ser acero/CuNi/equiv.`);
+        }
+        break;
+      }
+      case "no_slip_on_in_catA_munitions_accommodation": {
+        if (isSlipOn(ctx.joint)) {
+          if (note.prohibit_spaces.includes(ctx.space)) {
+            addTrace(`Nota ${noteId}: Slip-on prohibidas en ${ctx.space}.`);
+            reason = `Nota ${noteId}: slip-on no aceptadas en este espacio`;
+          } else if (
+            ctx.space === "other_machinery" &&
+            note.allow_other_machinery_if_visible_accessible &&
+            ctx.location !== "visible_accessible"
+          ) {
+            addCondition(NOTE2_LOCATION_CHIP);
+            addTrace(`Nota ${noteId}: En otros espacios de maquinaria deben quedar visibles y accesibles.`);
+          }
+        }
+        break;
+      }
+      case "fire_resistant_except_open_deck_low_fire_risk": {
+        if (ctx.space !== note.exception.space) {
+          addCondition(NOTE3_FIRE_CHIP);
+          addTrace(`Nota ${noteId}: Exigir tipo resistente al fuego salvo en cubierta abierta de bajo riesgo.`);
+        }
+        break;
+      }
+      case "fire_resistant_required": {
+        addCondition(NOTE4_FIRE_CHIP);
+        addTrace(`Nota ${noteId}: Requiere tipo resistente al fuego.`);
+        break;
+      }
+      case "restrained_slip_on_steam_open_deck_tankers_le_10bar": {
+        if (isSlipOn(ctx.joint)) {
+          const okPressure = (ctx.designPressure_bar ?? Number.POSITIVE_INFINITY) <= note.max_pressure_bar;
+          const okLocation = ctx.space === note.space;
+          const okShipType = note.ship_types.includes(ctx.shipType ?? "other");
+          const isRestrained = ctx.joint === "slip_on_machine_grooved";
+          if (okPressure && okLocation && okShipType && isRestrained) {
+            addCondition(NOTE5_STEAM_CHIP, false);
+            addTrace(
+              `Nota ${noteId}: Slip-on restringida permitida en cubierta expuesta para vapor ≤ ${note.max_pressure_bar} bar en petroleros/quimiqueros.`
+            );
+          } else {
+            addTrace(`Nota ${noteId}: Condiciones para restrained slip-on en vapor no satisfechas.`);
+            reason =
+              "Nota 5: solo se permiten restrained slip-on en cubierta expuesta de petroleros/quimiqueros con P ≤ 10 bar";
+          }
+        }
+        break;
+      }
+      case "only_above_limit_of_watertight_integrity": {
+        if (ctx.aboveLimitOfWatertightIntegrity === false) {
+          addTrace(`Nota ${noteId}: Aplicable solo sobre el límite de integridad estanca.`);
+          addCondition(NOTE6_WLI_CHIP);
+          reason = "Nota 6: solo permitido sobre el Límite de Integridad Estanca";
+        } else if (ctx.aboveLimitOfWatertightIntegrity !== undefined) {
+          addCondition(NOTE6_WLI_CHIP, false);
+          addTrace(`Nota ${noteId}: Confirmado sobre el límite de integridad estanca.`);
+        }
+        break;
+      }
+      case "hvac_trunking_intakes_uptakes_defer": {
+        addCondition(NOTE7_INFO_CHIP, false);
+        addTrace(`Nota ${noteId}: ${note.message}`);
+        skipGeneralClauses = true;
+        break;
+      }
+    }
+  }
+
+  if (reason) {
+    return forbid(ctx, trace, reason, undefined, conditions);
+  }
+
+  if (!skipGeneralClauses) {
+    const generalReason = applyGeneralClauses(ctx, sys, addCondition, addTrace);
+    if (generalReason) {
+      return forbid(ctx, trace, generalReason, undefined, conditions);
+    }
+  }
+
+  if (ctx.tailoring && (ctx.tailoring.shock || ctx.tailoring.fire || ctx.tailoring.watertight)) {
+    const requirements = [
+      ctx.tailoring.shock ? "Shock" : null,
+      ctx.tailoring.fire ? "Fire" : null,
+      ctx.tailoring.watertight ? "WT" : null,
+    ].filter(Boolean);
+    addCondition(`${TAILORING_CHIP_PREFIX} ${requirements.join("/") || "Shock/Fire/WT"}`);
+    addTrace("§5.10.2: Verificar requisitos de Tailoring Doc (autoridad naval).");
+  }
+
+  return {
+    status,
+    conditions,
+    normRef: normReference,
+    systemId: sys.id,
+    joint: ctx.joint,
+    pipeClass: ctx.pipeClass,
+    od_mm: ctx.od_mm,
+    designPressure_bar: ctx.designPressure_bar,
+    trace,
+  };
+}
+
+function applyGeneralClauses(
+  ctx: LRNavalShipsContext,
+  sys: NavalSystem,
+  addCondition: (msg: string, forceConditional?: boolean) => void,
+  addTrace: (msg: string) => void
+): string | null {
+  if (ctx.isSectionDirectlyConnectedToShipSide && ctx.aboveLimitOfWatertightIntegrity === false) {
+    addTrace("§5.10.6: Tramo conectado al costado bajo WLI → juntas mecánicas prohibidas.");
+    return "§5.10.6: no se permiten juntas si el tramo conectado al costado está bajo el WLI";
+  }
+
+  if (ctx.space === "tank" && (ctx.lineType === "fuel_oil" || ctx.lineType === "thermal_oil")) {
+    addTrace("§5.10.6: Tanques con fluidos inflamables → juntas mecánicas prohibidas.");
+    return "§5.10.6: juntas prohibidas en tanques con fluidos inflamables";
+  }
+
+  if (isSlipOn(ctx.joint)) {
+    if (ctx.accessibility === "not_easy") {
+      addTrace("§5.10.9: Slip-on prohibidas en ubicaciones de difícil acceso.");
+      return "§5.10.9: slip-on no permitidas si no hay acceso fácil";
+    }
+
+    if (ctx.space === "tank") {
+      if (ctx.mediumInPipeSameAsTank === true) {
+        addTrace("§5.10.9: Slip-on dentro de tanques solo si el medio es el mismo.");
+      } else {
+        addTrace("§5.10.9: Slip-on en tanques con medio diferente están prohibidas.");
+        return "§5.10.9: slip-on solo dentro de tanques con el mismo medio";
+      }
+    }
+
+    if (["cargo_hold", "cofferdam", "void"].includes(ctx.space)) {
+      addTrace("§5.10.9: Slip-on prohibidas en espacios no accesibles.");
+      return "§5.10.9: slip-on prohibidas en bodegas, cofferdams o voids";
+    }
+  }
+
+  if (ctx.joint === "slip_on_slip_type") {
+    if (ctx.mainMeansOfConnection) {
+      addCondition(SLIP_TYPE_WARNING, false);
+      addTrace("§5.10.10: Slip type no debe ser medio principal de conexión.");
+      return "§5.10.10: slip type no puede usarse como medio principal";
+    }
+    addCondition(SLIP_TYPE_WARNING, false);
+    addTrace("§5.10.10: Recordatorio – slip type solo para compensación axial.");
+  }
+
+  return null;
+}
+
+function groupOf(joint: Joint): JointGroup | null {
+  if (joint === "pipe_unions" || joint === "compression_couplings" || joint === "slip_on_joints") {
+    return joint;
+  }
+  if (joint === "pipe_union_welded_brazed") return "pipe_unions";
+  if (
+    joint === "compression_swage" ||
+    joint === "compression_typical" ||
+    joint === "compression_bite" ||
+    joint === "compression_flared" ||
+    joint === "compression_press"
+  ) {
+    return "compression_couplings";
+  }
+  if (
+    joint === "slip_on_machine_grooved" ||
+    joint === "slip_on_grip" ||
+    joint === "slip_on_slip_type"
+  ) {
+    return "slip_on_joints";
+  }
+  return null;
+}
+
+function isSlipOn(joint: Joint): boolean {
+  return groupOf(joint) === "slip_on_joints";
+}
+
+function describeJointGroup(group: JointGroup): string {
+  switch (group) {
+    case "pipe_unions":
+      return "pipe unions";
+    case "compression_couplings":
+      return "compression couplings";
+    case "slip_on_joints":
+      return "slip-on joints";
+  }
+}
+
+function passClassOD(
+  joint: Joint,
+  pipeClass: PipeClass | undefined,
+  odMM: number | undefined,
+  datasetOverride: NavalDataset
+): ClassCheckResult {
+  const rules = datasetOverride.pipe_class_rules.filter((rule) => rule.joint === joint);
+  const effectiveRules = rules.length
+    ? rules
+    : datasetOverride.pipe_class_rules.filter((rule) => groupOf(rule.joint) === joint);
+  if (!effectiveRules.length) {
+    return { ok: true };
+  }
+
+  if (!pipeClass) {
+    return { ok: false, reason: "missing_inputs" };
+  }
+
+  const match = effectiveRules.find((rule) => rule.class.includes(pipeClass));
+  if (!match) {
+    return { ok: false, reason: "limit" };
+  }
+
+  if (match.od_max_mm != null) {
+    if (typeof odMM !== "number") {
+      return { ok: false, reason: "missing_inputs" };
+    }
+    if (odMM > match.od_max_mm + 1e-6) {
+      return { ok: false, reason: "limit" };
+    }
+  }
+
+  const detail =
+    match.od_max_mm != null
+      ? `Tabla 1.5.4: Clase ${pipeClass} con OD ≤ ${match.od_max_mm} mm`
+      : `Tabla 1.5.4: Clase ${pipeClass}`;
+
+  return { ok: true, detail };
+}
+
+function forbid(
+  ctx: LRNavalShipsContext,
+  trace: string[],
+  message: string,
+  detail?: string,
+  conditions?: string[]
+): LRNavalShipsEvaluation {
+  if (detail) {
+    trace.push(detail);
+  }
+  return {
+    status: "forbidden",
+    conditions: conditions ? [...conditions] : [],
+    normRef: normReference,
+    reason: message,
+    systemId: ctx.systemId,
+    joint: ctx.joint,
+    pipeClass: ctx.pipeClass,
+    od_mm: ctx.od_mm,
+    designPressure_bar: ctx.designPressure_bar,
+    trace: [...trace],
+  };
+}
+
+export default evaluateLRNavalShips;

--- a/engine/lrShips.ts
+++ b/engine/lrShips.ts
@@ -233,7 +233,13 @@ function groupOf(joint: Joint): LRShipsJointGroup | null {
     return joint;
   }
   if (joint === "pipe_union_welded_brazed") return "pipe_unions";
-  if (joint === "compression_bite" || joint === "compression_flared" || joint === "compression_press") {
+  if (
+    joint === "compression_swage" ||
+    joint === "compression_typical" ||
+    joint === "compression_bite" ||
+    joint === "compression_flared" ||
+    joint === "compression_press"
+  ) {
     return "compression_couplings";
   }
   if (

--- a/tests/lrNavalShips.spec.ts
+++ b/tests/lrNavalShips.spec.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import evaluateLRNavalShips, {
+  type Joint,
+  type PipeClass,
+  type Space,
+} from "../dist/engine/evaluateLRNavalShips.js";
+
+function evaluate(options: {
+  systemId: string;
+  space: Space;
+  joint: Joint;
+  pipeClass?: PipeClass;
+  od_mm?: number;
+  designPressure_bar?: number;
+  isSectionDirectlyConnectedToShipSide?: boolean;
+  aboveLimitOfWatertightIntegrity?: boolean;
+  accessibility?: "easy" | "not_easy";
+  location?: "visible_accessible" | "normal";
+  mediumInPipeSameAsTank?: boolean;
+  lineType?: "fuel_oil" | "thermal_oil" | "other";
+  shipType?: "naval" | "oil_tanker" | "chemical_tanker" | "other";
+  tailoring?: { shock?: boolean; fire?: boolean; watertight?: boolean };
+  mainMeansOfConnection?: boolean;
+}) {
+  return evaluateLRNavalShips(options);
+}
+
+describe("evaluateLRNavalShips", () => {
+  it("marca condiciones para sistema de lastre en Cat. A con slip-on", () => {
+    const result = evaluate({
+      systemId: "ballast_system",
+      space: "machinery_cat_A",
+      joint: "slip_on_machine_grooved",
+      pipeClass: "II",
+      od_mm: 50,
+    });
+
+    expect(result.status).toBe("conditional");
+    expect(result.conditions).toContain("Ensayo de fuego: 8 min seco + 22 min húmedo");
+    expect(result.conditions).toContain(
+      "Tipo resistente al fuego si componentes se deterioran en incendio (Cat. A)"
+    );
+  });
+
+  it("aplica requisitos de bilge main en Cat. A con compresión", () => {
+    const result = evaluate({
+      systemId: "bilge_lines",
+      space: "machinery_cat_A",
+      joint: "compression_bite",
+      pipeClass: "II",
+      od_mm: 40,
+    });
+
+    expect(result.status).toBe("conditional");
+    expect(result.conditions).toContain("Ensayo de fuego: 8 min seco + 22 min húmedo");
+    expect(result.conditions).toContain("Material acople bilge main: acero/CuNi/equiv.");
+  });
+
+  it("bloquea slip-on en Cat. A para sistemas con Nota 2", () => {
+    const result = evaluate({
+      systemId: "machinery_fuel_oil_gt60",
+      space: "machinery_cat_A",
+      joint: "slip_on_grip",
+      pipeClass: "II",
+      od_mm: 40,
+    });
+
+    expect(result.status).toBe("forbidden");
+    expect(result.reason).toContain("Nota 2");
+  });
+
+  it("permite steam con restrained slip-on en cubierta expuesta ≤10 bar", () => {
+    const result = evaluate({
+      systemId: "steam",
+      space: "open_deck",
+      joint: "slip_on_machine_grooved",
+      pipeClass: "II",
+      od_mm: 40,
+      designPressure_bar: 8,
+      shipType: "oil_tanker",
+    });
+
+    expect(result.status).toBe("allowed");
+    expect(result.conditions).toContain(
+      "Restringido a cubierta expuesta ≤10 bar (vapor, petroleros/quimiqueros)"
+    );
+  });
+
+  it("rechaza steam slip-on fuera de condiciones de Nota 5", () => {
+    const result = evaluate({
+      systemId: "steam",
+      space: "open_deck",
+      joint: "slip_on_grip",
+      pipeClass: "II",
+      od_mm: 40,
+      designPressure_bar: 8,
+      shipType: "oil_tanker",
+    });
+
+    expect(result.status).toBe("forbidden");
+    expect(result.reason).toContain("Nota 5");
+  });
+
+  it("prohíbe slip-on en tanque con medio diferente", () => {
+    const result = evaluate({
+      systemId: "ballast_system",
+      space: "tank",
+      joint: "slip_on_machine_grooved",
+      pipeClass: "II",
+      od_mm: 50,
+      mediumInPipeSameAsTank: false,
+    });
+
+    expect(result.status).toBe("forbidden");
+    expect(result.reason).toContain("tanques");
+  });
+
+  it("prohíbe secciones conectadas al costado bajo el WLI", () => {
+    const result = evaluate({
+      systemId: "ballast_system",
+      space: "other_machinery",
+      joint: "compression_bite",
+      pipeClass: "II",
+      od_mm: 40,
+      isSectionDirectlyConnectedToShipSide: true,
+      aboveLimitOfWatertightIntegrity: false,
+    });
+
+    expect(result.status).toBe("forbidden");
+    expect(result.reason).toContain("§5.10.6");
+  });
+
+  it("prohíbe slip-on cuando no hay accesibilidad fácil", () => {
+    const result = evaluate({
+      systemId: "ballast_system",
+      space: "other_machinery",
+      joint: "slip_on_machine_grooved",
+      pipeClass: "II",
+      od_mm: 40,
+      accessibility: "not_easy",
+    });
+
+    expect(result.status).toBe("forbidden");
+    expect(result.reason).toContain("§5.10.9");
+  });
+});


### PR DESCRIPTION
## Summary
- add LR Naval Ships mechanical joint dataset including pipe-system rows, rules and notes
- implement evaluateLRNavalShips engine with clause, note and tailoring logic plus extend shared joint types
- add dedicated Vitest coverage for LR Naval Ships scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de76c1ed088321832f20b0c0624e08