### PR TITLE
Revamp LR joint evaluation flow

### DIFF
--- a/dist/engine/evaluateLRNavalShips.js
+++ b/dist/engine/evaluateLRNavalShips.js
@@ -17,233 +17,318 @@ const SLIP_TYPE_WARNING = "No como medio principal (slip-type)";
 const TAILORING_CHIP_PREFIX = "Tailoring Doc: validar";
 const db = dataset;
 export function evaluateLRNavalShips(ctx, datasetOverride = db) {
-    const trace = [];
     const sys = datasetOverride.systems.find((s) => s.id === ctx.systemId);
     if (!sys) {
-        return forbid(ctx, trace, "Sistema no reconocido");
+        return forbid(ctx, [], "Sistema no reconocido");
     }
     const jointGroup = groupOf(ctx.joint);
     if (!jointGroup) {
-        return forbid(ctx, trace, "Tipo de junta desconocido");
+        return forbid(ctx, [], "Tipo de junta desconocido");
     }
-    const allowedByRow = Boolean(sys.allowed_joints[jointGroup]);
-    trace.push(`Tabla 1.5.3 (${sys.label_es}): ${allowedByRow ? "+" : "–"} para ${describeJointGroup(jointGroup)}; clase '${sys.class_of_pipe_system}'.`);
-    if (!allowedByRow) {
-        return forbid(ctx, trace, "Tabla 1.5.3: '-' para este tipo de junta");
-    }
-    const classCheck = passClassOD(ctx.joint, ctx.pipeClass, ctx.od_mm, datasetOverride);
-    if (!classCheck.ok) {
-        if (classCheck.reason === "missing_inputs") {
-            return forbid(ctx, trace, "Falta clase/OD (Tabla 1.5.4)");
-        }
-        return forbid(ctx, trace, "Tabla 1.5.4: límite de clase/OD", classCheck.detail);
-    }
-    if (classCheck.detail) {
-        trace.push(classCheck.detail);
-    }
-    let status = sys.fire_test !== "not_required" ? "conditional" : "allowed";
-    let reason;
-    const conditions = [];
-    let skipGeneralClauses = false;
-    const addCondition = (msg, forceConditional = true) => {
-        if (!conditions.includes(msg)) {
-            conditions.push(msg);
-        }
-        if (forceConditional && status !== "forbidden") {
-            status = "conditional";
-        }
-    };
-    const addTrace = (msg) => {
-        trace.push(msg);
-    };
-    if (sys.fire_test !== "not_required") {
-        const label = FIRE_TEST_LABELS[sys.fire_test] ?? sys.fire_test;
-        addCondition(label, true);
-        addTrace(`Tabla 1.5.3: Ensayo base ${label}.`);
-    }
-    for (const noteId of sys.notes) {
-        if (reason)
-            break;
-        const note = datasetOverride.notes[String(noteId)];
-        if (!note)
-            continue;
-        switch (note.type) {
-            case "catA_fire_resistant_if_deteriorates_and_material_for_bilge_main": {
-                if (ctx.space === "machinery_cat_A" && note.catA_requires_fire_resistant) {
-                    addCondition(NOTE1_FIRE_CHIP);
-                    addTrace(`Nota ${noteId}: En Cat. A usar juntas resistentes al fuego si hay componentes que se deterioran.`);
-                }
-                if (ctx.space === "machinery_cat_A" && sys.id === "bilge_lines") {
-                    addCondition(NOTE1_BILGE_MATERIAL_CHIP);
-                    addTrace(`Nota ${noteId}: Acoples del bilge main en Cat. A deben ser acero/CuNi/equiv.`);
-                }
-                break;
+    const groups = evaluateGroupsForRow(ctx, sys, datasetOverride);
+    const groupResult = groups[jointGroup];
+    const trace = [...groupResult.trace];
+    const conditions = [...groupResult.conditions];
+    const observations = [...groupResult.observations];
+    const notesApplied = [...groupResult.notesApplied];
+    const generalClauses = [...groupResult.generalClauses];
+    const reasons = [...groupResult.reasons];
+    let status = groupResult.status;
+    let reason = reasons.length ? reasons[reasons.length - 1] : undefined;
+    if (status !== "forbidden") {
+        const classCheck = passClassOD(ctx.joint, ctx.pipeClass, ctx.od_mm, datasetOverride);
+        if (!classCheck.ok) {
+            if (classCheck.reason === "missing_inputs") {
+                reason = "Falta clase/OD (Tabla 1.5.4)";
             }
-            case "no_slip_on_in_catA_munitions_accommodation": {
-                if (isSlipOn(ctx.joint)) {
-                    if (note.prohibit_spaces.includes(ctx.space)) {
-                        addTrace(`Nota ${noteId}: Slip-on prohibidas en ${ctx.space}.`);
-                        reason = `Nota ${noteId}: slip-on no aceptadas en este espacio`;
-                    }
-                    else if (ctx.space === "other_machinery" &&
-                        note.allow_other_machinery_if_visible_accessible &&
-                        ctx.location !== "visible_accessible") {
-                        addCondition(NOTE2_LOCATION_CHIP);
-                        addTrace(`Nota ${noteId}: En otros espacios de maquinaria deben quedar visibles y accesibles.`);
-                    }
-                }
-                break;
+            else {
+                reason = "Tabla 1.5.4: límite de clase/OD";
             }
-            case "fire_resistant_except_open_deck_low_fire_risk": {
-                if (ctx.space !== note.exception.space) {
-                    addCondition(NOTE3_FIRE_CHIP);
-                    addTrace(`Nota ${noteId}: Exigir tipo resistente al fuego salvo en cubierta abierta de bajo riesgo.`);
-                }
-                break;
-            }
-            case "fire_resistant_required": {
-                addCondition(NOTE4_FIRE_CHIP);
-                addTrace(`Nota ${noteId}: Requiere tipo resistente al fuego.`);
-                break;
-            }
-            case "restrained_slip_on_steam_open_deck_tankers_le_10bar": {
-                if (isSlipOn(ctx.joint)) {
-                    const okPressure = (ctx.designPressure_bar ?? Number.POSITIVE_INFINITY) <= note.max_pressure_bar;
-                    const okLocation = ctx.space === note.space;
-                    const okShipType = note.ship_types.includes(ctx.shipType ?? "other");
-                    const isRestrained = ctx.joint === "slip_on_machine_grooved";
-                    if (okPressure && okLocation && okShipType && isRestrained) {
-                        addCondition(NOTE5_STEAM_CHIP, false);
-                        addTrace(`Nota ${noteId}: Slip-on restringida permitida en cubierta expuesta para vapor ≤ ${note.max_pressure_bar} bar en petroleros/quimiqueros.`);
-                    }
-                    else {
-                        addTrace(`Nota ${noteId}: Condiciones para restrained slip-on en vapor no satisfechas.`);
-                        reason =
-                            "Nota 5: solo se permiten restrained slip-on en cubierta expuesta de petroleros/quimiqueros con P ≤ 10 bar";
-                    }
-                }
-                break;
-            }
-            case "only_above_limit_of_watertight_integrity": {
-                if (ctx.aboveLimitOfWatertightIntegrity === false) {
-                    addTrace(`Nota ${noteId}: Aplicable solo sobre el límite de integridad estanca.`);
-                    addCondition(NOTE6_WLI_CHIP);
-                    reason = "Nota 6: solo permitido sobre el Límite de Integridad Estanca";
-                }
-                else if (ctx.aboveLimitOfWatertightIntegrity !== undefined) {
-                    addCondition(NOTE6_WLI_CHIP, false);
-                    addTrace(`Nota ${noteId}: Confirmado sobre el límite de integridad estanca.`);
-                }
-                break;
-            }
-            case "hvac_trunking_intakes_uptakes_defer": {
-                addCondition(NOTE7_INFO_CHIP, false);
-                addTrace(`Nota ${noteId}: ${note.message}`);
-                skipGeneralClauses = true;
-                break;
+            status = "forbidden";
+            if (classCheck.detail) {
+                pushOnce(observations, classCheck.detail);
             }
         }
-    }
-    if (reason) {
-        return forbid(ctx, trace, reason, undefined, conditions);
-    }
-    if (!skipGeneralClauses) {
-        const generalReason = applyGeneralClauses(ctx, sys, addCondition, addTrace);
-        if (generalReason) {
-            return forbid(ctx, trace, generalReason, undefined, conditions);
+        else if (classCheck.detail) {
+            trace.push(classCheck.detail);
         }
     }
-    if (ctx.tailoring && (ctx.tailoring.shock || ctx.tailoring.fire || ctx.tailoring.watertight)) {
+    if (status !== "forbidden" && ctx.tailoring && (ctx.tailoring.shock || ctx.tailoring.fire || ctx.tailoring.watertight)) {
         const requirements = [
             ctx.tailoring.shock ? "Shock" : null,
             ctx.tailoring.fire ? "Fire" : null,
             ctx.tailoring.watertight ? "WT" : null,
         ].filter(Boolean);
-        addCondition(`${TAILORING_CHIP_PREFIX} ${requirements.join("/") || "Shock/Fire/WT"}`);
-        addTrace("§5.10.2: Verificar requisitos de Tailoring Doc (autoridad naval).");
+        const label = `${TAILORING_CHIP_PREFIX} ${requirements.join("/") || "Shock/Fire/WT"}`;
+        pushOnce(conditions, label);
+        trace.push("§5.10.2: Verificar requisitos de Tailoring Doc (autoridad naval).");
     }
     return {
         status,
         conditions,
         normRef: normReference,
+        reason,
         systemId: sys.id,
         joint: ctx.joint,
         pipeClass: ctx.pipeClass,
         od_mm: ctx.od_mm,
         designPressure_bar: ctx.designPressure_bar,
         trace,
+        observations,
+        notesApplied,
+        generalClauses,
     };
 }
-function applyGeneralClauses(ctx, sys, addCondition, addTrace) {
-    if (ctx.isSectionDirectlyConnectedToShipSide && ctx.aboveLimitOfWatertightIntegrity === false) {
-        addTrace("§5.10.6: Tramo conectado al costado bajo WLI → juntas mecánicas prohibidas.");
-        return "§5.10.6: no se permiten juntas si el tramo conectado al costado está bajo el WLI";
+export function evaluateGroups(ctx, datasetOverride = db) {
+    const sys = datasetOverride.systems.find((s) => s.id === ctx.systemId);
+    if (!sys) {
+        throw new Error("Sistema no reconocido");
     }
-    if (ctx.space === "tank" && (ctx.lineType === "fuel_oil" || ctx.lineType === "thermal_oil")) {
-        addTrace("§5.10.6: Tanques con fluidos inflamables → juntas mecánicas prohibidas.");
-        return "§5.10.6: juntas prohibidas en tanques con fluidos inflamables";
-    }
-    if (isSlipOn(ctx.joint)) {
-        if (ctx.accessibility === "not_easy") {
-            addTrace("§5.10.9: Slip-on prohibidas en ubicaciones de difícil acceso.");
-            return "§5.10.9: slip-on no permitidas si no hay acceso fácil";
+    return evaluateGroupsForRow(ctx, sys, datasetOverride);
+}
+function evaluateGroupsForRow(ctx, row, datasetOverride) {
+    const groups = {
+        pipe_unions: base(Boolean(row.allowed_joints.pipe_unions), row, "pipe_unions"),
+        compression_couplings: base(Boolean(row.allowed_joints.compression_couplings), row, "compression_couplings"),
+        slip_on_joints: base(Boolean(row.allowed_joints.slip_on_joints), row, "slip_on_joints"),
+    };
+    const fireLabel = row.fire_test !== "not_required" ? FIRE_TEST_LABELS[row.fire_test] ?? row.fire_test : null;
+    if (fireLabel) {
+        for (const result of Object.values(groups)) {
+            if (result.status === "forbidden")
+                continue;
+            if (result.status === "allowed") {
+                result.status = "conditional";
+            }
+            pushOnce(result.conditions, fireLabel);
+            result.trace.push(`Tabla 1.5.3: Ensayo base ${fireLabel}.`);
         }
-        if (ctx.space === "tank") {
-            if (ctx.mediumInPipeSameAsTank === true) {
-                addTrace("§5.10.9: Slip-on dentro de tanques solo si el medio es el mismo.");
+    }
+    const rowNotes = new Set(row.notes);
+    for (const noteId of rowNotes) {
+        for (const [groupName, result] of Object.entries(groups)) {
+            if (result.status === "forbidden")
+                continue;
+            applyNote_LRNS(ctx, row, datasetOverride, noteId, groupName, result);
+        }
+    }
+    for (const [groupName, result] of Object.entries(groups)) {
+        if (result.status === "forbidden" || result.skipGeneralClauses)
+            continue;
+        applyGeneralClauses(ctx, groupName, result);
+    }
+    return groups;
+}
+function base(allowed, row, group) {
+    const result = {
+        status: allowed ? "allowed" : "forbidden",
+        conditions: [],
+        reasons: [],
+        observations: [],
+        notesApplied: [],
+        generalClauses: [],
+        trace: [],
+    };
+    const message = `Tabla 1.5.3 (${row.label_es}): ${allowed ? "+" : "–"} para ${describeJointGroup(group)}; clase '${row.class_of_pipe_system}'.`;
+    result.trace.push(message);
+    if (!allowed) {
+        result.reasons.push("Tabla de sistema: ‘-’");
+    }
+    return result;
+}
+function applyNote_LRNS(ctx, row, datasetOverride, noteId, group, out) {
+    const note = datasetOverride.notes[String(noteId)];
+    if (!note)
+        return;
+    switch (note.type) {
+        case "catA_fire_resistant_if_deteriorates_and_material_for_bilge_main": {
+            if (ctx.space === "machinery_cat_A" && note.catA_requires_fire_resistant) {
+                if (out.status === "allowed") {
+                    out.status = "conditional";
+                }
+                pushOnce(out.conditions, NOTE1_FIRE_CHIP);
+                pushOnce(out.notesApplied, noteId);
+                pushOnce(out.observations, "Nota 1: Cat. A requiere juntas resistentes al fuego si hay componentes que se deterioran.");
+                out.trace.push("Nota 1: Cat. A ⇒ tipo resistente al fuego.");
+            }
+            if (ctx.space === "machinery_cat_A" && row.id === "bilge_lines") {
+                if (out.status === "allowed") {
+                    out.status = "conditional";
+                }
+                pushOnce(out.conditions, NOTE1_BILGE_MATERIAL_CHIP);
+                pushOnce(out.notesApplied, noteId);
+                pushOnce(out.observations, "Nota 1: Acoples del bilge main en Cat. A deben ser acero/CuNi/equiv.");
+                out.trace.push("Nota 1: Bilge main ⇒ material acero/CuNi/equiv.");
+            }
+            break;
+        }
+        case "no_slip_on_in_catA_munitions_accommodation": {
+            if (group === "slip_on_joints") {
+                if (note.prohibit_spaces.includes(ctx.space)) {
+                    out.status = "forbidden";
+                    const message = "Nota 2: slip-on no aceptadas en Cat. A/municiones/aloj.";
+                    pushOnce(out.reasons, message);
+                    pushOnce(out.observations, message);
+                    pushOnce(out.notesApplied, noteId);
+                    out.trace.push(`Nota 2: Slip-on prohibidas en ${ctx.space}.`);
+                }
+                else if (ctx.space === "other_machinery" &&
+                    note.allow_other_machinery_if_visible_accessible &&
+                    ctx.location !== "visible_accessible") {
+                    if (out.status !== "forbidden") {
+                        out.status = "conditional";
+                    }
+                    pushOnce(out.conditions, NOTE2_LOCATION_CHIP);
+                    pushOnce(out.notesApplied, noteId);
+                    pushOnce(out.observations, "Nota 2: ubicar en posiciones visibles y accesibles.");
+                    out.trace.push("Nota 2: otras máquinas ⇒ visibles/accesibles.");
+                }
+            }
+            break;
+        }
+        case "fire_resistant_except_open_deck_low_fire_risk": {
+            if (ctx.space !== note.exception.space) {
+                if (out.status === "allowed") {
+                    out.status = "conditional";
+                }
+                pushOnce(out.conditions, NOTE3_FIRE_CHIP);
+                pushOnce(out.notesApplied, noteId);
+                pushOnce(out.observations, "Nota 3: requiere juntas de tipo resistente al fuego.");
+                out.trace.push("Nota 3: exigir tipo resistente al fuego.");
+            }
+            break;
+        }
+        case "fire_resistant_required": {
+            if (out.status === "allowed") {
+                out.status = "conditional";
+            }
+            pushOnce(out.conditions, NOTE4_FIRE_CHIP);
+            pushOnce(out.notesApplied, noteId);
+            pushOnce(out.observations, "Nota 4: requiere juntas de tipo resistente al fuego.");
+            out.trace.push("Nota 4: tipo resistente al fuego obligatorio.");
+            break;
+        }
+        case "restrained_slip_on_steam_open_deck_tankers_le_10bar": {
+            if (group === "slip_on_joints" && ctx.space === note.space) {
+                const okPressure = (ctx.designPressure_bar ?? Number.POSITIVE_INFINITY) <= note.max_pressure_bar;
+                const okShipType = note.ship_types.includes(ctx.shipType ?? "other");
+                const isRestrained = ctx.joint === "slip_on_machine_grooved";
+                if (okPressure && okShipType && isRestrained) {
+                    pushOnce(out.conditions, NOTE5_STEAM_CHIP);
+                    pushOnce(out.notesApplied, noteId);
+                    pushOnce(out.observations, "Nota 5: solo restrained slip-on en cubierta expuesta para vapor ≤10 bar (petroleros/quimiqueros).");
+                    out.trace.push("Nota 5: Condiciones satisfechas para restrained slip-on.");
+                }
+                else {
+                    out.status = "forbidden";
+                    const message = "Nota 5: solo se permiten restrained slip-on en cubierta expuesta de petroleros/quimiqueros con P ≤10 bar";
+                    pushOnce(out.reasons, message);
+                    pushOnce(out.observations, message);
+                    pushOnce(out.notesApplied, noteId);
+                    out.trace.push("Nota 5: Condiciones para restrained slip-on no satisfechas.");
+                }
+            }
+            break;
+        }
+        case "only_above_limit_of_watertight_integrity": {
+            if (ctx.aboveLimitOfWatertightIntegrity === false) {
+                out.status = "forbidden";
+                const message = "Nota 6: solo permitido sobre el Límite de Integridad Estanca";
+                pushOnce(out.reasons, message);
+                pushOnce(out.observations, message);
+                pushOnce(out.notesApplied, noteId);
+                out.trace.push("Nota 6: Sección bajo el Límite de Integridad Estanca ⇒ prohibido.");
             }
             else {
-                addTrace("§5.10.9: Slip-on en tanques con medio diferente están prohibidas.");
-                return "§5.10.9: slip-on solo dentro de tanques con el mismo medio";
+                if (out.status === "allowed") {
+                    out.status = "conditional";
+                }
+                pushOnce(out.conditions, NOTE6_WLI_CHIP);
+                pushOnce(out.notesApplied, noteId);
+                pushOnce(out.observations, "Nota 6: confirmar ubicación sobre el Límite de Integridad Estanca.");
+                out.trace.push("Nota 6: Requiere confirmar ubicación sobre el WLI.");
+            }
+            break;
+        }
+        case "hvac_trunking_intakes_uptakes_defer": {
+            pushOnce(out.conditions, NOTE7_INFO_CHIP);
+            pushOnce(out.notesApplied, noteId);
+            pushOnce(out.observations, `Nota 7: ${note.message}`);
+            out.trace.push(`Nota 7: ${note.message}`);
+            out.skipGeneralClauses = true;
+            break;
+        }
+    }
+}
+function applyGeneralClauses(ctx, group, out) {
+    const mediumSame = ctx.mediumInPipeSameAsTank;
+    if (ctx.isSectionDirectlyConnectedToShipSide &&
+        ctx.aboveLimitOfWatertightIntegrity === false) {
+        const message = "§5.10.6: tramo conectado al costado bajo el WLI ⇒ juntas prohibidas";
+        out.status = "forbidden";
+        pushOnce(out.generalClauses, message);
+        pushOnce(out.reasons, message);
+        pushOnce(out.observations, message);
+        out.trace.push(message);
+        return;
+    }
+    if (ctx.space === "tank" && (ctx.lineType === "fuel_oil" || ctx.lineType === "thermal_oil")) {
+        const message = "§5.10.6: juntas prohibidas en tanques con fluidos inflamables";
+        out.status = "forbidden";
+        pushOnce(out.generalClauses, message);
+        pushOnce(out.reasons, message);
+        pushOnce(out.observations, message);
+        out.trace.push(message);
+        return;
+    }
+    if (group === "slip_on_joints") {
+        if (ctx.accessibility === "not_easy") {
+            const message = "§5.10.9: slip-on prohibidas en ubicaciones de difícil acceso";
+            out.status = "forbidden";
+            pushOnce(out.generalClauses, message);
+            pushOnce(out.reasons, message);
+            pushOnce(out.observations, message);
+            out.trace.push(message);
+            return;
+        }
+        if (ctx.space === "tank") {
+            if (mediumSame === false) {
+                const message = "§5.10.9: slip-on en tanques solo si el medio es el mismo";
+                out.status = "forbidden";
+                pushOnce(out.generalClauses, message);
+                pushOnce(out.reasons, message);
+                pushOnce(out.observations, message);
+                out.trace.push(message);
+                return;
+            }
+            if (mediumSame === true) {
+                const message = "§5.10.9: confirmar medio en tanque igual al de la tubería";
+                pushOnce(out.generalClauses, message);
+                pushOnce(out.observations, message);
+                out.trace.push(message);
             }
         }
         if (["cargo_hold", "cofferdam", "void"].includes(ctx.space)) {
-            addTrace("§5.10.9: Slip-on prohibidas en espacios no accesibles.");
-            return "§5.10.9: slip-on prohibidas en bodegas, cofferdams o voids";
+            const message = "§5.10.9: slip-on prohibidas en bodegas/cofferdams/voids";
+            out.status = "forbidden";
+            pushOnce(out.generalClauses, message);
+            pushOnce(out.reasons, message);
+            pushOnce(out.observations, message);
+            out.trace.push(message);
+            return;
         }
     }
     if (ctx.joint === "slip_on_slip_type") {
+        pushOnce(out.conditions, SLIP_TYPE_WARNING);
+        out.trace.push("§5.10.10: Slip-type solo para compensación axial.");
         if (ctx.mainMeansOfConnection) {
-            addCondition(SLIP_TYPE_WARNING, false);
-            addTrace("§5.10.10: Slip type no debe ser medio principal de conexión.");
-            return "§5.10.10: slip type no puede usarse como medio principal";
+            const message = "§5.10.10: slip-type no puede ser medio principal";
+            out.status = "forbidden";
+            pushOnce(out.generalClauses, message);
+            pushOnce(out.reasons, message);
+            pushOnce(out.observations, message);
+            out.trace.push(message);
         }
-        addCondition(SLIP_TYPE_WARNING, false);
-        addTrace("§5.10.10: Recordatorio – slip type solo para compensación axial.");
-    }
-    return null;
-}
-function groupOf(joint) {
-    if (joint === "pipe_unions" || joint === "compression_couplings" || joint === "slip_on_joints") {
-        return joint;
-    }
-    if (joint === "pipe_union_welded_brazed")
-        return "pipe_unions";
-    if (joint === "compression_swage" ||
-        joint === "compression_typical" ||
-        joint === "compression_bite" ||
-        joint === "compression_flared" ||
-        joint === "compression_press") {
-        return "compression_couplings";
-    }
-    if (joint === "slip_on_machine_grooved" ||
-        joint === "slip_on_grip" ||
-        joint === "slip_on_slip_type") {
-        return "slip_on_joints";
-    }
-    return null;
-}
-function isSlipOn(joint) {
-    return groupOf(joint) === "slip_on_joints";
-}
-function describeJointGroup(group) {
-    switch (group) {
-        case "pipe_unions":
-            return "pipe unions";
-        case "compression_couplings":
-            return "compression couplings";
-        case "slip_on_joints":
-            return "slip-on joints";
     }
 }
 function passClassOD(joint, pipeClass, odMM, datasetOverride) {
@@ -274,13 +359,10 @@ function passClassOD(joint, pipeClass, odMM, datasetOverride) {
         : `Tabla 1.5.4: Clase ${pipeClass}`;
     return { ok: true, detail };
 }
-function forbid(ctx, trace, message, detail, conditions) {
-    if (detail) {
-        trace.push(detail);
-    }
+function forbid(ctx, trace, message) {
     return {
         status: "forbidden",
-        conditions: conditions ? [...conditions] : [],
+        conditions: [],
         normRef: normReference,
         reason: message,
         systemId: ctx.systemId,
@@ -289,6 +371,46 @@ function forbid(ctx, trace, message, detail, conditions) {
         od_mm: ctx.od_mm,
         designPressure_bar: ctx.designPressure_bar,
         trace: [...trace],
+        observations: [],
+        notesApplied: [],
+        generalClauses: [],
     };
+}
+function groupOf(joint) {
+    if (joint === "pipe_unions" || joint === "compression_couplings" || joint === "slip_on_joints") {
+        return joint;
+    }
+    if (joint === "pipe_union_welded_brazed")
+        return "pipe_unions";
+    if (joint === "compression_swage" ||
+        joint === "compression_typical" ||
+        joint === "compression_bite" ||
+        joint === "compression_flared" ||
+        joint === "compression_press") {
+        return "compression_couplings";
+    }
+    if (joint === "slip_on_machine_grooved" ||
+        joint === "slip_on_grip" ||
+        joint === "slip_on_slip_type") {
+        return "slip_on_joints";
+    }
+    return null;
+}
+function describeJointGroup(group) {
+    switch (group) {
+        case "pipe_unions":
+            return "pipe unions";
+        case "compression_couplings":
+            return "compression couplings";
+        case "slip_on_joints":
+            return "slip-on joints";
+    }
+}
+function pushOnce(arr, value) {
+    if (value === undefined || value === null)
+        return;
+    if (!arr.includes(value)) {
+        arr.push(value);
+    }
 }
 export default evaluateLRNavalShips;

--- a/dist/engine/lrShips.js
+++ b/dist/engine/lrShips.js
@@ -1,158 +1,303 @@
 import dataset from "../data/lr_ships_mech_joints.js";
 const normReference = "LR Ships Pt5 Ch12 §2.12, Tablas 12.2.8–12.2.9";
 export function evaluateLRShips(ctx, db = dataset) {
-    const trace = [];
     const sys = db.systems.find((s) => s.id === ctx.systemId);
     if (!sys) {
-        return forbid(ctx, trace, "Sistema no reconocido");
+        return forbid(ctx, [], "Sistema no reconocido");
     }
     const jointGroup = groupOf(ctx.joint);
     if (!jointGroup) {
-        return forbid(ctx, trace, "Tipo de junta desconocido");
+        return forbid(ctx, [], "Tipo de junta desconocido");
     }
-    const baseAllowed = Boolean(sys.allowed_joints[jointGroup]);
-    trace.push(`Tabla 12.2.8 (${sys.label_es}): ${baseAllowed ? "+" : "–"} para ${describeJointGroup(jointGroup)}; clasificación '${sys.class_of_pipe_system}'.`);
-    if (!baseAllowed) {
-        return forbid(ctx, trace, "Tabla 12.2.8: '-' para este tipo de junta");
-    }
-    const classResult = passClassOD(ctx.joint, ctx.pipeClass, ctx.od_mm, db);
-    if (!classResult.ok) {
-        if (classResult.reason === "missing_inputs") {
-            return forbid(ctx, trace, "Falta clase/OD para aplicar Tabla 12.2.9");
-        }
-        return forbid(ctx, trace, "Tabla 12.2.9: límite de clase/OD", classResult.detail);
-    }
-    if (classResult.detail) {
-        trace.push(classResult.detail);
-    }
-    let status = "allowed";
-    let forbiddenReason = null;
-    const conditions = [];
-    const addCondition = (msg) => {
-        if (!conditions.includes(msg)) {
-            conditions.push(msg);
-        }
-        status = status === "forbidden" ? status : "conditional";
-    };
-    const addTrace = (msg) => {
-        trace.push(msg);
-    };
-    if (sys.fire_test) {
-        const label = labelTest(sys.fire_test);
-        addCondition(label);
-        addTrace(`Tabla 12.2.8: Ensayo de fuego base ${label}.`);
-    }
-    for (const noteId of sys.notes) {
-        const note = db.notes[String(noteId)];
-        if (!note || forbiddenReason)
-            continue;
-        switch (note.type) {
-            case "fire_test_if_space": {
-                if (note.spaces.includes(ctx.space)) {
-                    const test = note.test === "from_row" ? sys.fire_test : note.test;
-                    if (test) {
-                        const label = labelTest(test);
-                        addCondition(label);
-                        addTrace(`Nota ${noteId}: espacio = ${ctx.space} ⇒ ${label}.`);
-                    }
-                }
-                break;
+    const groups = evaluateGroupsForRow(ctx, sys, db);
+    const groupResult = groups[jointGroup];
+    const trace = [...groupResult.trace];
+    const conditions = [...groupResult.conditions];
+    const observations = [...groupResult.observations];
+    const notesApplied = [...groupResult.notesApplied];
+    const generalClauses = [...groupResult.generalClauses];
+    const reasons = [...groupResult.reasons];
+    let status = groupResult.status;
+    let reason = reasons.length ? reasons[reasons.length - 1] : undefined;
+    if (status !== "forbidden") {
+        const classResult = passClassOD(ctx.joint, ctx.pipeClass, ctx.od_mm, db);
+        if (!classResult.ok) {
+            if (classResult.reason === "missing_inputs") {
+                reason = "Falta clase/OD para aplicar Tabla 12.2.9";
             }
-            case "prohibit_slip_on_in_spaces": {
-                if (isSlipOn(ctx.joint)) {
-                    if (note.prohibit.includes(ctx.space)) {
-                        addTrace(`Nota ${noteId}: Slip-on no aceptadas en ${ctx.space}.`);
-                        forbiddenReason = `Nota ${noteId}: slip-on no aceptadas en este espacio`;
-                    }
-                    else if (ctx.space === "other_machinery" &&
-                        note.allow_if === "other_machinery_visible_accessible" &&
-                        ctx.location !== "visible_accessible") {
-                        addCondition("Instalar en posiciones visibles y accesibles (MSC/Circ.734)");
-                        addTrace(`Nota ${noteId}: En otros espacios de maquinaria deben quedar visibles/accesibles.`);
-                    }
-                }
-                break;
+            else {
+                reason = "Tabla 12.2.9: límite de clase/OD";
             }
-            case "require_fire_resistant_type_except": {
-                if (!(ctx.space === note.except.space && ctx.lineType !== note.except.not_for)) {
-                    addCondition("Usar tipo resistente al fuego");
-                    addTrace(`Nota ${noteId}: exigir tipo resistente al fuego.`);
-                }
-                break;
-            }
-            case "only_above_bulkhead_deck_passenger_ships": {
-                addCondition("Solo sobre cubierta de francobordo en buques de pasaje");
-                addTrace(`Nota ${noteId}: limitada a cubierta superior en buques de pasaje.`);
-                break;
-            }
-            case "allow_slip_type_on_open_deck_max_pressure_bar": {
-                if (isSlipType(ctx.joint) &&
-                    ctx.space === "open_deck" &&
-                    (ctx.designPressure_bar ?? Number.POSITIVE_INFINITY) <= note.max_bar) {
-                    addTrace(`Nota ${noteId}: Slip-type permitido en cubierta hasta ${note.max_bar} bar.`);
-                }
-                else if (isSlipType(ctx.joint) && ctx.space === "open_deck") {
-                    addTrace(`Nota ${noteId}: P > ${note.max_bar} bar ⇒ Slip-type no permitido.`);
-                    forbiddenReason = `Nota ${noteId}: presión de diseño supera ${note.max_bar} bar`;
-                }
-                break;
-            }
-            case "test_equivalence": {
-                addTrace(`Nota ${noteId}: equivalencias de ensayo disponibles.`);
-                break;
-            }
-            case "reference_only": {
-                addTrace(`Nota ${noteId}: ${note.ref}.`);
-                break;
+            status = "forbidden";
+            if (classResult.detail) {
+                pushOnce(observations, classResult.detail);
             }
         }
-    }
-    if (forbiddenReason) {
-        return forbid(ctx, trace, forbiddenReason);
-    }
-    const generalReason = applyGeneralClauses(ctx, addCondition, addTrace);
-    if (generalReason) {
-        return forbid(ctx, trace, generalReason);
+        else if (classResult.detail) {
+            trace.push(classResult.detail);
+        }
     }
     return {
         status,
         conditions,
         normRef: normReference,
+        reason,
         systemId: sys.id,
         joint: ctx.joint,
         pipeClass: ctx.pipeClass,
         od_mm: ctx.od_mm,
         designPressure_bar: ctx.designPressure_bar,
         trace,
+        observations,
+        notesApplied,
+        generalClauses,
     };
 }
-function applyGeneralClauses(ctx, addCondition, addTrace) {
-    if (isSlipOn(ctx.joint)) {
-        if (["cargo_hold", "cofferdam", "void"].includes(ctx.space)) {
-            addTrace("§2.12.8: Slip-on prohibidas en bodegas/cofferdams/voids no accesibles.");
-            return "§2.12.8: slip-on prohibidas en espacios no accesibles";
+export function evaluateGroups(ctx, db = dataset) {
+    const row = db.systems.find((s) => s.id === ctx.systemId);
+    if (!row) {
+        throw new Error("Sistema no reconocido");
+    }
+    return evaluateGroupsForRow(ctx, row, db);
+}
+function evaluateGroupsForRow(ctx, row, db) {
+    const groups = {
+        pipe_unions: base(Boolean(row.allowed_joints.pipe_unions), row, "pipe_unions"),
+        compression_couplings: base(Boolean(row.allowed_joints.compression_couplings), row, "compression_couplings"),
+        slip_on_joints: base(Boolean(row.allowed_joints.slip_on_joints), row, "slip_on_joints"),
+    };
+    const rowNotes = new Set(row.notes);
+    const fireTestLabel = row.fire_test != null ? labelFire(row.fire_test) : null;
+    if (fireTestLabel) {
+        for (const result of Object.values(groups)) {
+            if (result.status === "forbidden")
+                continue;
+            if (result.status === "allowed") {
+                result.status = "conditional";
+            }
+            pushOnce(result.conditions, fireTestLabel);
+            result.trace.push(`Tabla 12.2.8: Ensayo base ${fireTestLabel}.`);
+        }
+    }
+    for (const note of rowNotes) {
+        for (const [groupName, result] of Object.entries(groups)) {
+            if (result.status === "forbidden")
+                continue;
+            applyNote_LR(ctx, row, note, groupName, result);
+        }
+    }
+    for (const [groupName, result] of Object.entries(groups)) {
+        if (result.status === "forbidden")
+            continue;
+        applyGeneralClauses(ctx, groupName, result);
+    }
+    return groups;
+}
+function base(allowed, row, group) {
+    const result = {
+        status: allowed ? "allowed" : "forbidden",
+        conditions: [],
+        reasons: [],
+        observations: [],
+        notesApplied: [],
+        generalClauses: [],
+        trace: [],
+    };
+    const baseMessage = `Tabla 12.2.8 (${row.label_es}): ${allowed ? "+" : "–"} para ${describeJointGroup(group)}; clasificación '${row.class_of_pipe_system}'.`;
+    result.trace.push(baseMessage);
+    if (!allowed) {
+        result.reasons.push("Tabla de sistema: ‘-’");
+    }
+    return result;
+}
+function pushOnce(arr, value) {
+    if (value === undefined || value === null)
+        return;
+    if (!arr.includes(value)) {
+        arr.push(value);
+    }
+}
+function applyNote_LR(ctx, row, note, group, out) {
+    switch (note) {
+        case 1: {
+            if (ctx.space === "pump_room" || ctx.space === "open_deck") {
+                const label = row.fire_test != null ? labelFire(row.fire_test) : null;
+                if (label) {
+                    if (out.status === "allowed") {
+                        out.status = "conditional";
+                    }
+                    pushOnce(out.conditions, label);
+                    pushOnce(out.notesApplied, note);
+                    const locationLabel = ctx.space === "pump_room" ? "sala de bombas" : "cubierta abierta";
+                    const message = `Nota 1: exige ${label} en ${locationLabel}.`;
+                    pushOnce(out.observations, message);
+                    out.trace.push(`Nota 1: espacio ${ctx.space} ⇒ ${label}.`);
+                }
+            }
+            break;
+        }
+        case 2: {
+            if (group === "slip_on_joints") {
+                if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
+                    out.status = "forbidden";
+                    const message = "Nota 2: slip-on no aceptadas en Cat. A/aloj.";
+                    pushOnce(out.reasons, message);
+                    pushOnce(out.observations, message);
+                    pushOnce(out.notesApplied, note);
+                    out.trace.push(`Nota 2: Slip-on prohibidas en ${ctx.space}.`);
+                }
+                else if (ctx.space === "other_machinery" && ctx.location !== "visible_accessible") {
+                    if (out.status !== "forbidden") {
+                        out.status = "conditional";
+                    }
+                    const condition = "Ubicar en posiciones visibles y accesibles (MSC/Circ.734)";
+                    pushOnce(out.conditions, condition);
+                    pushOnce(out.observations, "Nota 2: requiere ubicación visible y accesible en otras máquinas.");
+                    pushOnce(out.notesApplied, note);
+                    out.trace.push("Nota 2: otras máquinas ⇒ visibles/accesibles.");
+                }
+            }
+            break;
+        }
+        case 3: {
+            const exceptOpenDeck = ctx.space === "open_deck";
+            const exceptFuel = ctx.lineType && ctx.lineType !== "fuel_oil";
+            if (!(exceptOpenDeck && exceptFuel)) {
+                if (out.status === "allowed") {
+                    out.status = "conditional";
+                }
+                const condition = "Junta de tipo resistente al fuego";
+                pushOnce(out.conditions, condition);
+                pushOnce(out.notesApplied, note);
+                pushOnce(out.observations, "Nota 3: requiere junta de tipo resistente al fuego (salvo cubierta abierta).");
+                out.trace.push("Nota 3: exigir tipo resistente al fuego.");
+            }
+            break;
+        }
+        case 4: {
+            if (ctx.space === "machinery_cat_A") {
+                const label = row.fire_test != null ? labelFire(row.fire_test) : null;
+                if (label) {
+                    if (out.status === "allowed") {
+                        out.status = "conditional";
+                    }
+                    pushOnce(out.conditions, label);
+                    pushOnce(out.notesApplied, note);
+                    pushOnce(out.observations, "Nota 4: Cat. A exige ensayo de fuego del sistema.");
+                    out.trace.push(`Nota 4: Cat. A ⇒ ${label}.`);
+                }
+            }
+            break;
+        }
+        case 5: {
+            if (ctx.space !== "open_deck") {
+                const condition = "Solo sobre cubierta de francobordo en buques de pasaje";
+                if (out.status === "allowed") {
+                    out.status = "conditional";
+                }
+                pushOnce(out.conditions, condition);
+                pushOnce(out.notesApplied, note);
+                pushOnce(out.observations, "Nota 5: limitar a cubierta de francobordo en buques de pasaje.");
+                out.trace.push("Nota 5: limitar ubicación a cubierta de francobordo.");
+            }
+            break;
+        }
+        case 6: {
+            if (ctx.joint === "slip_on_slip_type") {
+                if (ctx.space === "open_deck" && (ctx.designPressure_bar ?? Number.POSITIVE_INFINITY) <= 10) {
+                    if (out.status === "allowed") {
+                        out.status = "conditional";
+                    }
+                    pushOnce(out.notesApplied, note);
+                    pushOnce(out.conditions, "Slip-type ≤10 bar en cubierta expuesta");
+                    pushOnce(out.observations, "Nota 6: Slip-type restringido a cubierta abierta ≤10 bar.");
+                    out.trace.push("Nota 6: Slip-type permitido en cubierta abierta con P ≤10 bar.");
+                }
+                else if (ctx.space === "open_deck") {
+                    out.status = "forbidden";
+                    const message = "Nota 6: presión de diseño supera 10 bar";
+                    pushOnce(out.reasons, message);
+                    pushOnce(out.observations, message);
+                    pushOnce(out.notesApplied, note);
+                    out.trace.push("Nota 6: presión excede 10 bar ⇒ prohibido.");
+                }
+            }
+            break;
+        }
+        case 7: {
+            pushOnce(out.notesApplied, note);
+            const message = "Nota 7: equivalencias de ensayo disponibles";
+            pushOnce(out.observations, message);
+            out.trace.push(message);
+            break;
+        }
+        case 8: {
+            pushOnce(out.notesApplied, note);
+            const message = "Nota 8: ver §2.12.10 para slip-on restringidas";
+            pushOnce(out.observations, message);
+            out.trace.push(message);
+            break;
+        }
+    }
+}
+function applyGeneralClauses(ctx, group, out) {
+    const mediumSame = ctx.mediumInPipeSameAsTank ?? ctx.sameMediumInTank;
+    if (ctx.directToShipSideBelowLimit) {
+        const message = "§2.12.5: no usar juntas en conexión directa al costado bajo el límite";
+        out.status = "forbidden";
+        pushOnce(out.generalClauses, message);
+        pushOnce(out.reasons, message);
+        pushOnce(out.observations, message);
+        out.trace.push(message);
+        return;
+    }
+    if (ctx.tankContainsFlammable) {
+        const message = "§2.12.5: prohibidas en tanques con fluidos inflamables";
+        out.status = "forbidden";
+        pushOnce(out.generalClauses, message);
+        pushOnce(out.reasons, message);
+        pushOnce(out.observations, message);
+        out.trace.push(message);
+        return;
+    }
+    if (group === "slip_on_joints") {
+        if (ctx.accessibility === "not_easy") {
+            const message = "§2.12.8: slip-on no en espacios de difícil acceso";
+            out.status = "forbidden";
+            pushOnce(out.generalClauses, message);
+            pushOnce(out.reasons, message);
+            pushOnce(out.observations, message);
+            out.trace.push(message);
+            return;
         }
         if (ctx.space === "tank") {
-            if (ctx.sameMediumInTank) {
-                addCondition("Solo dentro de tanques cuando contienen el mismo medio");
-                addTrace("§2.12.8: En tanques solo si el medio es el mismo.");
+            if (mediumSame === false) {
+                const message = "§2.12.8: slip-on en tanques solo si el medio es el mismo";
+                out.status = "forbidden";
+                pushOnce(out.generalClauses, message);
+                pushOnce(out.reasons, message);
+                pushOnce(out.observations, message);
+                out.trace.push(message);
+                return;
             }
-            else {
-                addTrace("§2.12.8: Slip-on no permitidas en tanques con medio distinto.");
-                return "§2.12.8: slip-on solo dentro de tanques con el mismo medio";
+            if (mediumSame === true) {
+                const message = "§2.12.8: confirmar mismo medio en tanque";
+                pushOnce(out.generalClauses, message);
+                pushOnce(out.observations, message);
+                out.trace.push(message);
             }
         }
     }
-    if (ctx.joint === "slip_on_slip_type") {
-        addCondition("No usar como medio principal salvo compensación axial (§2.12.9)");
-        addTrace("§2.12.9: Slip-type limitado a compensación axial.");
+    if (ctx.joint === "slip_on_slip_type" && ctx.asMainMeans) {
+        const message = "§2.12.9: slip-type no puede ser medio principal (solo compensación axial)";
+        out.status = "forbidden";
+        pushOnce(out.generalClauses, message);
+        pushOnce(out.reasons, message);
+        pushOnce(out.observations, message);
+        out.trace.push(message);
     }
-    return null;
 }
-function forbid(ctx, trace, message, detail) {
-    if (detail) {
-        trace.push(detail);
-    }
+function forbid(ctx, trace, message) {
     return {
         status: "forbidden",
         conditions: [],
@@ -164,6 +309,9 @@ function forbid(ctx, trace, message, detail) {
         od_mm: ctx.od_mm,
         designPressure_bar: ctx.designPressure_bar,
         trace: [...trace],
+        observations: [],
+        notesApplied: [],
+        generalClauses: [],
     };
 }
 function groupOf(joint) {
@@ -186,13 +334,7 @@ function groupOf(joint) {
     }
     return null;
 }
-function isSlipOn(joint) {
-    return groupOf(joint) === "slip_on_joints";
-}
-function isSlipType(joint) {
-    return joint === "slip_on_slip_type";
-}
-function labelTest(value) {
+function labelFire(value) {
     switch (value) {
         case "30min_dry":
             return "Ensayo fuego 30 min seco";

--- a/tests/lrShips.spec.ts
+++ b/tests/lrShips.spec.ts
@@ -38,6 +38,7 @@ describe("evaluateLRShips", () => {
     });
     expect(result.status).toBe("conditional");
     expect(result.conditions).toContain("Ensayo fuego 8 min seco + 22 min húmedo");
+    expect(result.observations.some((msg) => msg.includes("Nota 2"))).toBe(false);
   });
 
   it("bloquea slip-on en acomodaciones por Nota 2", () => {


### PR DESCRIPTION
## Summary
- refactor LR Ships evaluation to compute group results before subtype checks, track conditions/observations, and limit note handling to the system row
- align LR Naval Ships evaluation with the same ordered logic for notes, fire tests, and general clauses while exporting group evaluations
- extend the LR Ships test to ensure bilge lines show the fire-test condition without falsely reporting Note 2

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7ca69fd08321912c15df13d0a552