### PR TITLE
Scope LR evaluations to row notes and refine observations

### DIFF
--- a/asesor-grip-type-multi.html
+++ b/asesor-grip-type-multi.html
@@ -989,9 +989,16 @@
                 </div>
                 <div className="bg-slate-800/40 border border-slate-700/40 rounded-2xl p-5">
                   <h2 className="text-lg font-semibold mb-3">Observaciones (evaluación)</h2>
-                  ${evaluation.observations?.length
-                    ? html`<ul className="observations-list">${evaluation.observations.map((obs, idx) => html`<li key=${idx}>${obs}</li>`)}</ul>`
-                    : html`<p className="text-sm text-slate-400">Sin observaciones adicionales para las condiciones ingresadas.</p>`}
+                  ${(() => {
+                    const applied = evaluation
+                      ? Array.from(
+                          new Set([...(evaluation.conditions ?? []), ...(evaluation.reasons ?? [])])
+                        )
+                      : [];
+                    return applied.length
+                      ? html`<ul className="observations-list">${applied.map((obs, idx) => html`<li key=${idx}>${obs}</li>`)}</ul>`
+                      : html`<p className="text-sm text-slate-400">Sin observaciones adicionales para las condiciones ingresadas.</p>`;
+                  })()}
                 </div>
               </section>
 

--- a/dist/engine/evaluateLRNavalShips.js
+++ b/dist/engine/evaluateLRNavalShips.js
@@ -29,7 +29,6 @@ export function evaluateLRNavalShips(ctx, datasetOverride = db) {
     const groupResult = groups[jointGroup];
     const trace = [...groupResult.trace];
     const conditions = [...groupResult.conditions];
-    const observations = [...groupResult.observations];
     const notesApplied = [...groupResult.notesApplied];
     const generalClauses = [...groupResult.generalClauses];
     const reasons = [...groupResult.reasons];
@@ -45,8 +44,9 @@ export function evaluateLRNavalShips(ctx, datasetOverride = db) {
                 reason = "Tabla 1.5.4: límite de clase/OD";
             }
             status = "forbidden";
+            pushOnce(reasons, reason);
             if (classCheck.detail) {
-                pushOnce(observations, classCheck.detail);
+                trace.push(classCheck.detail);
             }
         }
         else if (classCheck.detail) {
@@ -63,9 +63,11 @@ export function evaluateLRNavalShips(ctx, datasetOverride = db) {
         pushOnce(conditions, label);
         trace.push("§5.10.2: Verificar requisitos de Tailoring Doc (autoridad naval).");
     }
+    const observations = Array.from(new Set([...conditions, ...reasons]));
     return {
         status,
         conditions,
+        reasons,
         normRef: normReference,
         reason,
         systemId: sys.id,
@@ -92,30 +94,27 @@ function evaluateGroupsForRow(ctx, row, datasetOverride) {
         compression_couplings: base(Boolean(row.allowed_joints.compression_couplings), row, "compression_couplings"),
         slip_on_joints: base(Boolean(row.allowed_joints.slip_on_joints), row, "slip_on_joints"),
     };
-    const fireLabel = row.fire_test !== "not_required" ? FIRE_TEST_LABELS[row.fire_test] ?? row.fire_test : null;
-    if (fireLabel) {
-        for (const result of Object.values(groups)) {
-            if (result.status === "forbidden")
-                continue;
+    const rowNotes = new Set(row?.notes ?? []);
+    const fireLabel = row.fire_test && row.fire_test !== "not_required"
+        ? FIRE_TEST_LABELS[row.fire_test] ?? row.fire_test
+        : null;
+    for (const [groupName, result] of Object.entries(groups)) {
+        if (!Boolean(row.allowed_joints[groupName])) {
+            continue;
+        }
+        if (fireLabel) {
             if (result.status === "allowed") {
                 result.status = "conditional";
             }
             pushOnce(result.conditions, fireLabel);
             result.trace.push(`Tabla 1.5.3: Ensayo base ${fireLabel}.`);
         }
-    }
-    const rowNotes = new Set(row.notes);
-    for (const noteId of rowNotes) {
-        for (const [groupName, result] of Object.entries(groups)) {
-            if (result.status === "forbidden")
-                continue;
-            applyNote_LRNS(ctx, row, datasetOverride, noteId, groupName, result);
+        for (const noteId of rowNotes) {
+            applyNoteScoped_LRNavalShips(noteId, ctx, row, datasetOverride, groupName, result);
         }
-    }
-    for (const [groupName, result] of Object.entries(groups)) {
-        if (result.status === "forbidden" || result.skipGeneralClauses)
-            continue;
-        applyGeneralClauses(ctx, groupName, result);
+        if (!result.skipGeneralClauses) {
+            applyGeneralClauses(ctx, groupName, result);
+        }
     }
     return groups;
 }
@@ -124,7 +123,6 @@ function base(allowed, row, group) {
         status: allowed ? "allowed" : "forbidden",
         conditions: [],
         reasons: [],
-        observations: [],
         notesApplied: [],
         generalClauses: [],
         trace: [],
@@ -136,125 +134,109 @@ function base(allowed, row, group) {
     }
     return result;
 }
-function applyNote_LRNS(ctx, row, datasetOverride, noteId, group, out) {
-    const note = datasetOverride.notes[String(noteId)];
-    if (!note)
+function applyNoteScoped_LRNavalShips(noteId, ctx, row, datasetOverride, group, out) {
+    if (out.status === "forbidden") {
         return;
-    switch (note.type) {
-        case "catA_fire_resistant_if_deteriorates_and_material_for_bilge_main": {
-            if (ctx.space === "machinery_cat_A" && note.catA_requires_fire_resistant) {
+    }
+    switch (noteId) {
+        case 1: {
+            if (ctx.space === "machinery_cat_A") {
                 if (out.status === "allowed") {
                     out.status = "conditional";
                 }
                 pushOnce(out.conditions, NOTE1_FIRE_CHIP);
                 pushOnce(out.notesApplied, noteId);
-                pushOnce(out.observations, "Nota 1: Cat. A requiere juntas resistentes al fuego si hay componentes que se deterioran.");
-                out.trace.push("Nota 1: Cat. A ⇒ tipo resistente al fuego.");
-            }
-            if (ctx.space === "machinery_cat_A" && row.id === "bilge_lines") {
-                if (out.status === "allowed") {
-                    out.status = "conditional";
+                out.trace.push("Nota 1: Cat. A ⇒ juntas resistentes al fuego.");
+                if (row.id === "bilge_lines") {
+                    pushOnce(out.conditions, NOTE1_BILGE_MATERIAL_CHIP);
                 }
-                pushOnce(out.conditions, NOTE1_BILGE_MATERIAL_CHIP);
-                pushOnce(out.notesApplied, noteId);
-                pushOnce(out.observations, "Nota 1: Acoples del bilge main en Cat. A deben ser acero/CuNi/equiv.");
-                out.trace.push("Nota 1: Bilge main ⇒ material acero/CuNi/equiv.");
             }
             break;
         }
-        case "no_slip_on_in_catA_munitions_accommodation": {
+        case 2: {
             if (group === "slip_on_joints") {
-                if (note.prohibit_spaces.includes(ctx.space)) {
+                if (ctx.space === "machinery_cat_A" ||
+                    ctx.space === "munitions_store" ||
+                    ctx.space === "accommodation") {
                     out.status = "forbidden";
-                    const message = "Nota 2: slip-on no aceptadas en Cat. A/municiones/aloj.";
+                    const message = "Nota 2: Slip-on no aceptadas en Cat. A/municiones/aloj.";
                     pushOnce(out.reasons, message);
-                    pushOnce(out.observations, message);
                     pushOnce(out.notesApplied, noteId);
                     out.trace.push(`Nota 2: Slip-on prohibidas en ${ctx.space}.`);
                 }
-                else if (ctx.space === "other_machinery" &&
-                    note.allow_other_machinery_if_visible_accessible &&
-                    ctx.location !== "visible_accessible") {
-                    if (out.status !== "forbidden") {
-                        out.status = "conditional";
-                    }
+                else if (ctx.space === "other_machinery" && ctx.location !== "visible_accessible") {
+                    out.status = "conditional";
                     pushOnce(out.conditions, NOTE2_LOCATION_CHIP);
                     pushOnce(out.notesApplied, noteId);
-                    pushOnce(out.observations, "Nota 2: ubicar en posiciones visibles y accesibles.");
                     out.trace.push("Nota 2: otras máquinas ⇒ visibles/accesibles.");
                 }
             }
             break;
         }
-        case "fire_resistant_except_open_deck_low_fire_risk": {
-            if (ctx.space !== note.exception.space) {
+        case 3: {
+            if (ctx.space !== "open_deck_low_risk_SOLAS_9_2_3_3_2_2_10") {
                 if (out.status === "allowed") {
                     out.status = "conditional";
                 }
                 pushOnce(out.conditions, NOTE3_FIRE_CHIP);
                 pushOnce(out.notesApplied, noteId);
-                pushOnce(out.observations, "Nota 3: requiere juntas de tipo resistente al fuego.");
-                out.trace.push("Nota 3: exigir tipo resistente al fuego.");
+                out.trace.push("Nota 3: exigir juntas resistentes al fuego.");
             }
             break;
         }
-        case "fire_resistant_required": {
+        case 4: {
             if (out.status === "allowed") {
                 out.status = "conditional";
             }
             pushOnce(out.conditions, NOTE4_FIRE_CHIP);
             pushOnce(out.notesApplied, noteId);
-            pushOnce(out.observations, "Nota 4: requiere juntas de tipo resistente al fuego.");
             out.trace.push("Nota 4: tipo resistente al fuego obligatorio.");
             break;
         }
-        case "restrained_slip_on_steam_open_deck_tankers_le_10bar": {
-            if (group === "slip_on_joints" && ctx.space === note.space) {
-                const okPressure = (ctx.designPressure_bar ?? Number.POSITIVE_INFINITY) <= note.max_pressure_bar;
-                const okShipType = note.ship_types.includes(ctx.shipType ?? "other");
+        case 5: {
+            if (group === "slip_on_joints" && row.id === "steam") {
                 const isRestrained = ctx.joint === "slip_on_machine_grooved";
-                if (okPressure && okShipType && isRestrained) {
+                const onOpenDeck = ctx.space === "open_deck";
+                const allowedShip = ["oil_tanker", "chemical_tanker"].includes(ctx.shipType ?? "");
+                const pressureOk = (ctx.designPressure_bar ?? Number.POSITIVE_INFINITY) <= 10;
+                if (isRestrained && onOpenDeck && allowedShip && pressureOk) {
+                    if (out.status === "allowed") {
+                        out.status = "conditional";
+                    }
                     pushOnce(out.conditions, NOTE5_STEAM_CHIP);
                     pushOnce(out.notesApplied, noteId);
-                    pushOnce(out.observations, "Nota 5: solo restrained slip-on en cubierta expuesta para vapor ≤10 bar (petroleros/quimiqueros).");
                     out.trace.push("Nota 5: Condiciones satisfechas para restrained slip-on.");
                 }
                 else {
                     out.status = "forbidden";
-                    const message = "Nota 5: solo se permiten restrained slip-on en cubierta expuesta de petroleros/quimiqueros con P ≤10 bar";
+                    const message = "Nota 5: sólo restrained slip-on ≤10 bar en cubierta expuesta (petroleros/quimiqueros)";
                     pushOnce(out.reasons, message);
-                    pushOnce(out.observations, message);
                     pushOnce(out.notesApplied, noteId);
                     out.trace.push("Nota 5: Condiciones para restrained slip-on no satisfechas.");
                 }
             }
             break;
         }
-        case "only_above_limit_of_watertight_integrity": {
+        case 6: {
             if (ctx.aboveLimitOfWatertightIntegrity === false) {
                 out.status = "forbidden";
-                const message = "Nota 6: solo permitido sobre el Límite de Integridad Estanca";
+                const message = "Nota 6: Sólo sobre el Límite de Integridad Estanca";
                 pushOnce(out.reasons, message);
-                pushOnce(out.observations, message);
                 pushOnce(out.notesApplied, noteId);
-                out.trace.push("Nota 6: Sección bajo el Límite de Integridad Estanca ⇒ prohibido.");
-            }
-            else {
-                if (out.status === "allowed") {
-                    out.status = "conditional";
-                }
-                pushOnce(out.conditions, NOTE6_WLI_CHIP);
-                pushOnce(out.notesApplied, noteId);
-                pushOnce(out.observations, "Nota 6: confirmar ubicación sobre el Límite de Integridad Estanca.");
-                out.trace.push("Nota 6: Requiere confirmar ubicación sobre el WLI.");
+                out.trace.push("Nota 6: Ubicación bajo el WLI ⇒ prohibido.");
             }
             break;
         }
-        case "hvac_trunking_intakes_uptakes_defer": {
+        case 7: {
             pushOnce(out.conditions, NOTE7_INFO_CHIP);
             pushOnce(out.notesApplied, noteId);
-            pushOnce(out.observations, `Nota 7: ${note.message}`);
-            out.trace.push(`Nota 7: ${note.message}`);
+            const note = datasetOverride.notes[String(noteId)];
+            if (note && "message" in note) {
+                out.trace.push(`Nota 7: ${note.message}`);
+            }
+            else {
+                out.trace.push("Nota 7: verificar requisitos adicionales (HVAC/intakes/uprakes).");
+            }
             out.skipGeneralClauses = true;
             break;
         }
@@ -268,7 +250,6 @@ function applyGeneralClauses(ctx, group, out) {
         out.status = "forbidden";
         pushOnce(out.generalClauses, message);
         pushOnce(out.reasons, message);
-        pushOnce(out.observations, message);
         out.trace.push(message);
         return;
     }
@@ -277,7 +258,6 @@ function applyGeneralClauses(ctx, group, out) {
         out.status = "forbidden";
         pushOnce(out.generalClauses, message);
         pushOnce(out.reasons, message);
-        pushOnce(out.observations, message);
         out.trace.push(message);
         return;
     }
@@ -287,7 +267,6 @@ function applyGeneralClauses(ctx, group, out) {
             out.status = "forbidden";
             pushOnce(out.generalClauses, message);
             pushOnce(out.reasons, message);
-            pushOnce(out.observations, message);
             out.trace.push(message);
             return;
         }
@@ -297,15 +276,8 @@ function applyGeneralClauses(ctx, group, out) {
                 out.status = "forbidden";
                 pushOnce(out.generalClauses, message);
                 pushOnce(out.reasons, message);
-                pushOnce(out.observations, message);
                 out.trace.push(message);
                 return;
-            }
-            if (mediumSame === true) {
-                const message = "§5.10.9: confirmar medio en tanque igual al de la tubería";
-                pushOnce(out.generalClauses, message);
-                pushOnce(out.observations, message);
-                out.trace.push(message);
             }
         }
         if (["cargo_hold", "cofferdam", "void"].includes(ctx.space)) {
@@ -313,7 +285,6 @@ function applyGeneralClauses(ctx, group, out) {
             out.status = "forbidden";
             pushOnce(out.generalClauses, message);
             pushOnce(out.reasons, message);
-            pushOnce(out.observations, message);
             out.trace.push(message);
             return;
         }
@@ -326,7 +297,6 @@ function applyGeneralClauses(ctx, group, out) {
             out.status = "forbidden";
             pushOnce(out.generalClauses, message);
             pushOnce(out.reasons, message);
-            pushOnce(out.observations, message);
             out.trace.push(message);
         }
     }
@@ -363,6 +333,7 @@ function forbid(ctx, trace, message) {
     return {
         status: "forbidden",
         conditions: [],
+        reasons: [message],
         normRef: normReference,
         reason: message,
         systemId: ctx.systemId,
@@ -371,7 +342,7 @@ function forbid(ctx, trace, message) {
         od_mm: ctx.od_mm,
         designPressure_bar: ctx.designPressure_bar,
         trace: [...trace],
-        observations: [],
+        observations: [message],
         notesApplied: [],
         generalClauses: [],
     };

--- a/dist/engine/lrShips.js
+++ b/dist/engine/lrShips.js
@@ -13,7 +13,6 @@ export function evaluateLRShips(ctx, db = dataset) {
     const groupResult = groups[jointGroup];
     const trace = [...groupResult.trace];
     const conditions = [...groupResult.conditions];
-    const observations = [...groupResult.observations];
     const notesApplied = [...groupResult.notesApplied];
     const generalClauses = [...groupResult.generalClauses];
     const reasons = [...groupResult.reasons];
@@ -29,17 +28,20 @@ export function evaluateLRShips(ctx, db = dataset) {
                 reason = "Tabla 12.2.9: límite de clase/OD";
             }
             status = "forbidden";
+            pushOnce(reasons, reason);
             if (classResult.detail) {
-                pushOnce(observations, classResult.detail);
+                trace.push(classResult.detail);
             }
         }
         else if (classResult.detail) {
             trace.push(classResult.detail);
         }
     }
+    const observations = Array.from(new Set([...conditions, ...reasons]));
     return {
         status,
         conditions,
+        reasons,
         normRef: normReference,
         reason,
         systemId: sys.id,
@@ -60,35 +62,28 @@ export function evaluateGroups(ctx, db = dataset) {
     }
     return evaluateGroupsForRow(ctx, row, db);
 }
-function evaluateGroupsForRow(ctx, row, db) {
+function evaluateGroupsForRow(ctx, row, _db) {
     const groups = {
         pipe_unions: base(Boolean(row.allowed_joints.pipe_unions), row, "pipe_unions"),
         compression_couplings: base(Boolean(row.allowed_joints.compression_couplings), row, "compression_couplings"),
         slip_on_joints: base(Boolean(row.allowed_joints.slip_on_joints), row, "slip_on_joints"),
     };
-    const rowNotes = new Set(row.notes);
-    const fireTestLabel = row.fire_test != null ? labelFire(row.fire_test) : null;
-    if (fireTestLabel) {
-        for (const result of Object.values(groups)) {
-            if (result.status === "forbidden")
-                continue;
+    const rowNotes = new Set(row?.notes ?? []);
+    const fireTestLabel = row?.fire_test ? labelFire(row.fire_test) : null;
+    for (const [groupName, result] of Object.entries(groups)) {
+        if (!Boolean(row.allowed_joints[groupName])) {
+            continue;
+        }
+        if (fireTestLabel) {
             if (result.status === "allowed") {
                 result.status = "conditional";
             }
             pushOnce(result.conditions, fireTestLabel);
             result.trace.push(`Tabla 12.2.8: Ensayo base ${fireTestLabel}.`);
         }
-    }
-    for (const note of rowNotes) {
-        for (const [groupName, result] of Object.entries(groups)) {
-            if (result.status === "forbidden")
-                continue;
-            applyNote_LR(ctx, row, note, groupName, result);
+        for (const note of rowNotes) {
+            applyNoteScoped_LRShips(note, ctx, row, groupName, result);
         }
-    }
-    for (const [groupName, result] of Object.entries(groups)) {
-        if (result.status === "forbidden")
-            continue;
         applyGeneralClauses(ctx, groupName, result);
     }
     return groups;
@@ -98,7 +93,6 @@ function base(allowed, row, group) {
         status: allowed ? "allowed" : "forbidden",
         conditions: [],
         reasons: [],
-        observations: [],
         notesApplied: [],
         generalClauses: [],
         trace: [],
@@ -117,20 +111,21 @@ function pushOnce(arr, value) {
         arr.push(value);
     }
 }
-function applyNote_LR(ctx, row, note, group, out) {
+function applyNoteScoped_LRShips(note, ctx, row, group, out) {
+    if (out.status === "forbidden") {
+        // Mantener primer motivo que bloqueó la evaluación.
+        return;
+    }
     switch (note) {
         case 1: {
             if (ctx.space === "pump_room" || ctx.space === "open_deck") {
-                const label = row.fire_test != null ? labelFire(row.fire_test) : null;
+                const label = row.fire_test ? labelFire(row.fire_test) : null;
                 if (label) {
                     if (out.status === "allowed") {
                         out.status = "conditional";
                     }
                     pushOnce(out.conditions, label);
                     pushOnce(out.notesApplied, note);
-                    const locationLabel = ctx.space === "pump_room" ? "sala de bombas" : "cubierta abierta";
-                    const message = `Nota 1: exige ${label} en ${locationLabel}.`;
-                    pushOnce(out.observations, message);
                     out.trace.push(`Nota 1: espacio ${ctx.space} ⇒ ${label}.`);
                 }
             }
@@ -140,19 +135,15 @@ function applyNote_LR(ctx, row, note, group, out) {
             if (group === "slip_on_joints") {
                 if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
                     out.status = "forbidden";
-                    const message = "Nota 2: slip-on no aceptadas en Cat. A/aloj.";
+                    const message = "Nota 2: Slip-on no aceptadas en Cat. A/aloj.";
                     pushOnce(out.reasons, message);
-                    pushOnce(out.observations, message);
                     pushOnce(out.notesApplied, note);
                     out.trace.push(`Nota 2: Slip-on prohibidas en ${ctx.space}.`);
                 }
                 else if (ctx.space === "other_machinery" && ctx.location !== "visible_accessible") {
-                    if (out.status !== "forbidden") {
-                        out.status = "conditional";
-                    }
-                    const condition = "Ubicar en posiciones visibles y accesibles (MSC/Circ.734)";
+                    out.status = "conditional";
+                    const condition = "Ubicación visible y accesible (MSC/Circ.734)";
                     pushOnce(out.conditions, condition);
-                    pushOnce(out.observations, "Nota 2: requiere ubicación visible y accesible en otras máquinas.");
                     pushOnce(out.notesApplied, note);
                     out.trace.push("Nota 2: otras máquinas ⇒ visibles/accesibles.");
                 }
@@ -160,30 +151,26 @@ function applyNote_LR(ctx, row, note, group, out) {
             break;
         }
         case 3: {
-            const exceptOpenDeck = ctx.space === "open_deck";
-            const exceptFuel = ctx.lineType && ctx.lineType !== "fuel_oil";
-            if (!(exceptOpenDeck && exceptFuel)) {
+            if (ctx.space !== "open_deck") {
                 if (out.status === "allowed") {
                     out.status = "conditional";
                 }
-                const condition = "Junta de tipo resistente al fuego";
+                const condition = "Tipo resistente al fuego";
                 pushOnce(out.conditions, condition);
                 pushOnce(out.notesApplied, note);
-                pushOnce(out.observations, "Nota 3: requiere junta de tipo resistente al fuego (salvo cubierta abierta).");
                 out.trace.push("Nota 3: exigir tipo resistente al fuego.");
             }
             break;
         }
         case 4: {
             if (ctx.space === "machinery_cat_A") {
-                const label = row.fire_test != null ? labelFire(row.fire_test) : null;
+                const label = row.fire_test ? labelFire(row.fire_test) : null;
                 if (label) {
                     if (out.status === "allowed") {
                         out.status = "conditional";
                     }
                     pushOnce(out.conditions, label);
                     pushOnce(out.notesApplied, note);
-                    pushOnce(out.observations, "Nota 4: Cat. A exige ensayo de fuego del sistema.");
                     out.trace.push(`Nota 4: Cat. A ⇒ ${label}.`);
                 }
             }
@@ -191,33 +178,32 @@ function applyNote_LR(ctx, row, note, group, out) {
         }
         case 5: {
             if (ctx.space !== "open_deck") {
-                const condition = "Solo sobre cubierta de francobordo en buques de pasaje";
                 if (out.status === "allowed") {
                     out.status = "conditional";
                 }
+                const condition = "Sólo sobre cubierta de francobordo (buques de pasaje)";
                 pushOnce(out.conditions, condition);
                 pushOnce(out.notesApplied, note);
-                pushOnce(out.observations, "Nota 5: limitar a cubierta de francobordo en buques de pasaje.");
-                out.trace.push("Nota 5: limitar ubicación a cubierta de francobordo.");
+                out.trace.push("Nota 5: limitar a cubierta de francobordo.");
             }
             break;
         }
         case 6: {
-            if (ctx.joint === "slip_on_slip_type") {
-                if (ctx.space === "open_deck" && (ctx.designPressure_bar ?? Number.POSITIVE_INFINITY) <= 10) {
+            if (ctx.joint === "slip_on_slip_type" && ctx.space === "open_deck") {
+                const maxPressure = ctx.designPressure_bar ?? Number.POSITIVE_INFINITY;
+                if (maxPressure <= 10) {
                     if (out.status === "allowed") {
                         out.status = "conditional";
                     }
+                    const condition = "Slip-type ≤10 bar en cubierta expuesta";
+                    pushOnce(out.conditions, condition);
                     pushOnce(out.notesApplied, note);
-                    pushOnce(out.conditions, "Slip-type ≤10 bar en cubierta expuesta");
-                    pushOnce(out.observations, "Nota 6: Slip-type restringido a cubierta abierta ≤10 bar.");
-                    out.trace.push("Nota 6: Slip-type permitido en cubierta abierta con P ≤10 bar.");
+                    out.trace.push("Nota 6: Slip-type permitido ≤10 bar.");
                 }
-                else if (ctx.space === "open_deck") {
+                else {
                     out.status = "forbidden";
-                    const message = "Nota 6: presión de diseño supera 10 bar";
+                    const message = "Nota 6: Slip-type >10 bar prohibido";
                     pushOnce(out.reasons, message);
-                    pushOnce(out.observations, message);
                     pushOnce(out.notesApplied, note);
                     out.trace.push("Nota 6: presión excede 10 bar ⇒ prohibido.");
                 }
@@ -225,17 +211,11 @@ function applyNote_LR(ctx, row, note, group, out) {
             break;
         }
         case 7: {
-            pushOnce(out.notesApplied, note);
-            const message = "Nota 7: equivalencias de ensayo disponibles";
-            pushOnce(out.observations, message);
-            out.trace.push(message);
+            out.trace.push("Nota 7: revisar equivalencias de ensayo.");
             break;
         }
         case 8: {
-            pushOnce(out.notesApplied, note);
-            const message = "Nota 8: ver §2.12.10 para slip-on restringidas";
-            pushOnce(out.observations, message);
-            out.trace.push(message);
+            out.trace.push("Nota 8: ver §2.12.10 para slip-on restringidas.");
             break;
         }
     }
@@ -243,20 +223,18 @@ function applyNote_LR(ctx, row, note, group, out) {
 function applyGeneralClauses(ctx, group, out) {
     const mediumSame = ctx.mediumInPipeSameAsTank ?? ctx.sameMediumInTank;
     if (ctx.directToShipSideBelowLimit) {
-        const message = "§2.12.5: no usar juntas en conexión directa al costado bajo el límite";
+        const message = "§2.12.5: prohibido conectar directamente al costado bajo el límite";
         out.status = "forbidden";
         pushOnce(out.generalClauses, message);
         pushOnce(out.reasons, message);
-        pushOnce(out.observations, message);
         out.trace.push(message);
         return;
     }
     if (ctx.tankContainsFlammable) {
-        const message = "§2.12.5: prohibidas en tanques con fluidos inflamables";
+        const message = "§2.12.5: prohibido en tanques con fluidos inflamables";
         out.status = "forbidden";
         pushOnce(out.generalClauses, message);
         pushOnce(out.reasons, message);
-        pushOnce(out.observations, message);
         out.trace.push(message);
         return;
     }
@@ -266,34 +244,23 @@ function applyGeneralClauses(ctx, group, out) {
             out.status = "forbidden";
             pushOnce(out.generalClauses, message);
             pushOnce(out.reasons, message);
-            pushOnce(out.observations, message);
             out.trace.push(message);
             return;
         }
-        if (ctx.space === "tank") {
-            if (mediumSame === false) {
-                const message = "§2.12.8: slip-on en tanques solo si el medio es el mismo";
-                out.status = "forbidden";
-                pushOnce(out.generalClauses, message);
-                pushOnce(out.reasons, message);
-                pushOnce(out.observations, message);
-                out.trace.push(message);
-                return;
-            }
-            if (mediumSame === true) {
-                const message = "§2.12.8: confirmar mismo medio en tanque";
-                pushOnce(out.generalClauses, message);
-                pushOnce(out.observations, message);
-                out.trace.push(message);
-            }
+        if (ctx.space === "tank" && mediumSame === false) {
+            const message = "§2.12.8: slip-on en tanques sólo si el medio es el mismo";
+            out.status = "forbidden";
+            pushOnce(out.generalClauses, message);
+            pushOnce(out.reasons, message);
+            out.trace.push(message);
+            return;
         }
     }
     if (ctx.joint === "slip_on_slip_type" && ctx.asMainMeans) {
-        const message = "§2.12.9: slip-type no puede ser medio principal (solo compensación axial)";
+        const message = "§2.12.9: Slip-type no como medio principal (sólo compensación axial)";
         out.status = "forbidden";
         pushOnce(out.generalClauses, message);
         pushOnce(out.reasons, message);
-        pushOnce(out.observations, message);
         out.trace.push(message);
     }
 }
@@ -301,6 +268,7 @@ function forbid(ctx, trace, message) {
     return {
         status: "forbidden",
         conditions: [],
+        reasons: [message],
         normRef: normReference,
         reason: message,
         systemId: ctx.systemId,
@@ -309,7 +277,7 @@ function forbid(ctx, trace, message) {
         od_mm: ctx.od_mm,
         designPressure_bar: ctx.designPressure_bar,
         trace: [...trace],
-        observations: [],
+        observations: [message],
         notesApplied: [],
         generalClauses: [],
     };

--- a/tests/lrNavalShips.spec.ts
+++ b/tests/lrNavalShips.spec.ts
@@ -26,13 +26,13 @@ function evaluate(options: {
 }
 
 describe("evaluateLRNavalShips", () => {
-  it("marca condiciones para sistema de lastre en Cat. A con slip-on", () => {
+  it("marca condiciones para bilge Cat. A (Clase III) con slip-on", () => {
     const result = evaluate({
-      systemId: "ballast_system",
+      systemId: "bilge_lines",
       space: "machinery_cat_A",
       joint: "slip_on_machine_grooved",
-      pipeClass: "II",
-      od_mm: 50,
+      pipeClass: "III",
+      od_mm: 76,
     });
 
     expect(result.status).toBe("conditional");
@@ -40,6 +40,8 @@ describe("evaluateLRNavalShips", () => {
     expect(result.conditions).toContain(
       "Tipo resistente al fuego si componentes se deterioran en incendio (Cat. A)"
     );
+    expect(result.conditions).toContain("Material acople bilge main: acero/CuNi/equiv.");
+    expect(result.reasons.some((msg) => msg.includes("Nota 2"))).toBe(false);
   });
 
   it("aplica requisitos de bilge main en Cat. A con compresión", () => {
@@ -69,7 +71,7 @@ describe("evaluateLRNavalShips", () => {
     expect(result.reason).toContain("Nota 2");
   });
 
-  it("permite steam con restrained slip-on en cubierta expuesta ≤10 bar", () => {
+  it("condiciona steam con restrained slip-on en cubierta expuesta ≤10 bar", () => {
     const result = evaluate({
       systemId: "steam",
       space: "open_deck",
@@ -80,7 +82,7 @@ describe("evaluateLRNavalShips", () => {
       shipType: "oil_tanker",
     });
 
-    expect(result.status).toBe("allowed");
+    expect(result.status).toBe("conditional");
     expect(result.conditions).toContain(
       "Restringido a cubierta expuesta ≤10 bar (vapor, petroleros/quimiqueros)"
     );
@@ -99,6 +101,7 @@ describe("evaluateLRNavalShips", () => {
 
     expect(result.status).toBe("forbidden");
     expect(result.reason).toContain("Nota 5");
+    expect(result.reasons.some((msg) => msg.includes("Nota 5"))).toBe(true);
   });
 
   it("prohíbe slip-on en tanque con medio diferente", () => {

--- a/tests/lrShips.spec.ts
+++ b/tests/lrShips.spec.ts
@@ -38,7 +38,7 @@ describe("evaluateLRShips", () => {
     });
     expect(result.status).toBe("conditional");
     expect(result.conditions).toContain("Ensayo fuego 8 min seco + 22 min húmedo");
-    expect(result.observations.some((msg) => msg.includes("Nota 2"))).toBe(false);
+    expect(result.reasons.some((msg) => msg.includes("Nota 2"))).toBe(false);
   });
 
   it("bloquea slip-on en acomodaciones por Nota 2", () => {
@@ -89,5 +89,31 @@ describe("evaluateLRShips", () => {
     });
     expect(result.status).toBe("forbidden");
     expect(result.reason).toContain("tanques");
+  });
+
+  it("marca ensayo combinado y Nota 4 para slip-on en bilge Cat. A (Clase III)", () => {
+    const result = evaluate({
+      systemId: "bilge_lines",
+      space: "machinery_cat_A",
+      joint: "slip_on_machine_grooved",
+      pipeClass: "III",
+      od_mm: 76,
+    });
+    expect(result.status).toBe("conditional");
+    expect(result.conditions).toContain("Ensayo fuego 8 min seco + 22 min húmedo");
+    expect(result.notesApplied).toContain(4);
+    expect(result.reasons.some((msg) => msg.includes("Nota 2"))).toBe(false);
+  });
+
+  it("bloquea slip-on Grip en Clase I por Tabla 12.2.9", () => {
+    const result = evaluate({
+      systemId: "sanitary",
+      space: "other_machinery",
+      joint: "slip_on_grip",
+      pipeClass: "I",
+      od_mm: 50,
+    });
+    expect(result.status).toBe("forbidden");
+    expect(result.reason).toBe("Tabla 12.2.9: límite de clase/OD");
   });
 });


### PR DESCRIPTION
## Summary
- scope LR Ships and LR Naval note execution to row-level notes, restructure evaluation order, and record applied reasons
- tighten general clause checks and slip-on handling, while deriving observations from conditions and reasons
- update the UI observations panel to filter applied items and extend test coverage for the new evaluation rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de921728e08321b2c3f871a9db57b5