### PR TITLE
Align LR Ships mechanical joint rules with Pt5 Ch12 updates

### DIFF
--- a/data/lr_ships_mech_joints.ts
+++ b/data/lr_ships_mech_joints.ts
@@ -6,7 +6,7 @@ export interface LRShipsSystem {
   label_en?: string;
   group?: string;
   class_of_pipe_system: "dry" | "wet" | "dry/wet";
-  fire_test: "30min_dry" | "30min_wet" | "8min_dry_plus_22min_wet" | null;
+  fire_test: "30min_dry" | "30min_wet" | "8+22" | "not_required";
   notes: number[];
   allowed_joints: Partial<Record<LRShipsJointGroup, boolean>>;
 }
@@ -57,7 +57,7 @@ export type LRShipsNote =
   | {
       type: "fire_test_if_space";
       spaces: Space[];
-      test: "from_row" | "30min_dry" | "30min_wet" | "8min_dry_plus_22min_wet";
+      test: "from_row" | "30min_dry" | "30min_wet" | "8+22";
     }
   | {
       type: "prohibit_slip_on_in_spaces";
@@ -72,10 +72,7 @@ export type LRShipsNote =
   | { type: "allow_slip_type_on_open_deck_max_pressure_bar"; max_bar: number }
   | {
       type: "test_equivalence";
-      equivalences: Record<
-        "30min_dry" | "30min_wet" | "8min_dry_plus_22min_wet",
-        "30min_dry" | "30min_wet" | "8min_dry_plus_22min_wet"
-      >;
+      equivalences: Record<"30min_dry" | "30min_wet" | "8+22", "30min_dry" | "30min_wet" | "8+22">;
     }
   | { type: "reference_only"; ref: string };
 
@@ -101,7 +98,7 @@ export const LR_SHIPS_DATASET: LRShipsDataset = {
       label_es: "Líneas de achique",
       label_en: "Bilge lines",
       class_of_pipe_system: "dry/wet",
-      fire_test: "8min_dry_plus_22min_wet",
+      fire_test: "8+22",
       notes: [4],
       allowed_joints: {
         pipe_unions: true,
@@ -167,7 +164,7 @@ export const LR_SHIPS_DATASET: LRShipsDataset = {
       label_es: "Sistema sanitario",
       label_en: "Sanitary system",
       class_of_pipe_system: "wet",
-      fire_test: null,
+      fire_test: "not_required",
       notes: [],
       allowed_joints: {
         pipe_unions: true,
@@ -182,7 +179,7 @@ export const LR_SHIPS_DATASET: LRShipsDataset = {
       class: ["I", "II", "III"],
       od_max_mm: { I: 60.3, II: 60.3 },
     },
-    { joint: "compression_swage", class: ["III"] },
+    { joint: "compression_swage", class: ["I", "II", "III"] },
     {
       joint: "compression_bite",
       class: ["I", "II", "III"],
@@ -220,8 +217,8 @@ export const LR_SHIPS_DATASET: LRShipsDataset = {
     "7": {
       type: "test_equivalence",
       equivalences: {
-        "30min_dry": "8min_dry_plus_22min_wet",
-        "8min_dry_plus_22min_wet": "30min_dry",
+        "30min_dry": "8+22",
+        "8+22": "30min_dry",
         "30min_wet": "30min_wet",
       },
     },

--- a/dist/data/lr_ships_mech_joints.js
+++ b/dist/data/lr_ships_mech_joints.js
@@ -20,7 +20,7 @@ export const LR_SHIPS_DATASET = {
             label_es: "Líneas de achique",
             label_en: "Bilge lines",
             class_of_pipe_system: "dry/wet",
-            fire_test: "8min_dry_plus_22min_wet",
+            fire_test: "8+22",
             notes: [4],
             allowed_joints: {
                 pipe_unions: true,
@@ -86,7 +86,7 @@ export const LR_SHIPS_DATASET = {
             label_es: "Sistema sanitario",
             label_en: "Sanitary system",
             class_of_pipe_system: "wet",
-            fire_test: null,
+            fire_test: "not_required",
             notes: [],
             allowed_joints: {
                 pipe_unions: true,
@@ -101,7 +101,7 @@ export const LR_SHIPS_DATASET = {
             class: ["I", "II", "III"],
             od_max_mm: { I: 60.3, II: 60.3 },
         },
-        { joint: "compression_swage", class: ["III"] },
+        { joint: "compression_swage", class: ["I", "II", "III"] },
         {
             joint: "compression_bite",
             class: ["I", "II", "III"],
@@ -139,8 +139,8 @@ export const LR_SHIPS_DATASET = {
         "7": {
             type: "test_equivalence",
             equivalences: {
-                "30min_dry": "8min_dry_plus_22min_wet",
-                "8min_dry_plus_22min_wet": "30min_dry",
+                "30min_dry": "8+22",
+                "8+22": "30min_dry",
                 "30min_wet": "30min_wet",
             },
         },

--- a/engines.js
+++ b/engines.js
@@ -1,16 +1,18 @@
 const BASE_COUPLING_RULES = {
   pipeUnions: (clazz, odMM) => {
     if (clazz === "III") {
-      return { allowed: true, reason: "+ (sin límite de OD en Clase III)" };
+      return { allowed: true, reason: "Tabla 12.2.9: Clase III sin límite de OD" };
     }
     const ok = odMM <= 60.3;
     return {
       allowed: ok,
-      reason: ok ? "+ (OD ≤ 60,3 mm en Clase I/II)" : "En Clase I/II solo se permite OD ≤ 60,3 mm.",
+      reason: ok
+        ? "Tabla 12.2.9: Clase I/II con OD ≤ 60,3 mm"
+        : "Tabla 12.2.9: Clase I/II sólo hasta OD 60,3 mm",
     };
   },
   compressionSubtypes: (clazz, odMM) => ({
-    swage: clazz === "III",
+    swage: true,
     bite: clazz === "III" ? true : odMM <= 60.3,
     typical: clazz === "III" ? true : odMM <= 60.3,
     flared: clazz === "III" ? true : odMM <= 60.3,
@@ -144,13 +146,13 @@ export class BaseEngine {
       if (!compressionAllowed) {
         const odDisplay = formatNumber(ctx.odMM);
         ctx.observations.push(
-          `En Clase ${ctx.usedClass}${ctx.usedClass !== "III" ? ` y OD ${odDisplay} mm` : ""} no queda ningún subtipo de compresión permitido.`
+          `Tabla 12.2.9: En Clase ${ctx.usedClass}${ctx.usedClass !== "III" ? ` y OD ${odDisplay} mm` : ""} no queda ningún subtipo de compresión permitido.`
         );
       } else {
         if (ctx.usedClass !== "III") {
-          ctx.observations.push("Swage/Press solo en Clase III.");
+          ctx.observations.push("Tabla 12.2.9: Press solo permitido en Clase III.");
           if (ctx.odMM > 60.3) {
-            ctx.observations.push("En Clase I/II, Bite/Typical/Flared solo hasta OD 60,3 mm.");
+            ctx.observations.push("Tabla 12.2.9: En Clase I/II, Bite/Typical/Flared solo hasta OD 60,3 mm.");
           }
         }
       }

--- a/tests/lrShips.spec.ts
+++ b/tests/lrShips.spec.ts
@@ -1,102 +1,60 @@
 import { describe, expect, it } from "vitest";
 import evaluateLRShips, {
+  SUBTYPE_RULES,
   evaluateGroups as evaluateLRShipsGroups,
-  type Joint,
-  type PipeClass,
-  type Space,
+  passClassOD,
 } from "../dist/engine/lrShips.js";
-import lrShipsDataset from "../dist/data/lr_ships_mech_joints.js";
-
-function evaluate(options: {
-  systemId: string;
-  space: Space;
-  joint: Joint;
-  pipeClass?: PipeClass;
-  od_mm?: number;
-  designPressure_bar?: number;
-  lineType?: "fuel_oil" | "thermal_oil" | "other";
-  location?: "visible_accessible" | "normal";
-}) {
-  return evaluateLRShips(options);
-}
-
-function pass(joint: Joint, pipeClass: PipeClass, od?: number) {
-  const rule = lrShipsDataset.pipe_class_rules.find((entry) => entry.joint === joint);
-  if (!rule) {
-    throw new Error(`No existe regla para ${joint}`);
-  }
-  if (!rule.class.includes(pipeClass)) {
-    return false;
-  }
-  const limit = rule.od_max_mm?.[pipeClass];
-  if (limit == null) {
-    return true;
-  }
-  if (od === undefined) {
-    return false;
-  }
-  return od <= limit + 1e-6;
-}
 
 describe("evaluateLRShips", () => {
-  it("marca condicional líneas de carga de hidrocarburos en Cat. A, Clase III", () => {
-    const result = evaluate({
+  it("marca condicional las slip-on en líneas de carga de hidrocarburos Cat. A Clase II", () => {
+    const result = evaluateLRShips({
       systemId: "hydrocarbon_loading_lines",
       space: "machinery_cat_A",
-      pipeClass: "III",
-      od_mm: 73,
-      joint: "slip_on_joints",
-    });
-
-    expect(result.status).toBe("conditional");
-    expect(result.conditions.join(" ")).toMatch(/30 min seco/);
-    expect(result.reasons).toHaveLength(0);
-  });
-
-  it("habilita slip-on condicional en otros espacios accesibles para carga de hidrocarburos", () => {
-    const r = evaluate({
-      systemId: "hydrocarbon_loading_lines",
-      space: "other_machinery_accessible",
       pipeClass: "II",
-      od_mm: 48.3,
+      od_mm: 60.3,
       joint: "slip_on_joints",
       accessibility: "easy",
     });
 
-    expect(r.status).toBe("conditional");
-    expect(r.reasons).toHaveLength(0);
-    expect(r.conditions.join(" ")).toMatch(/30 min seco/);
+    expect(result.status).toBe("conditional");
+    expect(result.conditions).toContain("30 min seco");
+    expect(result.reasons).toHaveLength(0);
   });
 
-  it("verifica Tabla 12.2.9 por subtipo", () => {
-    expect(pass("slip_on_machine_grooved", "III", 73)).toBe(true);
-    expect(pass("slip_on_grip", "III", 73)).toBe(true);
-    expect(pass("compression_press", "III", 73)).toBe(true);
-    expect(pass("pipe_union_welded_brazed", "III", 141.3)).toBe(true);
+  it("valida Swage y Press según Tabla 12.2.9 para Clase II", () => {
+    const swageRule = SUBTYPE_RULES.compression_couplings.find((rule) => rule.id === "swage");
+    const pressRule = SUBTYPE_RULES.compression_couplings.find((rule) => rule.id === "press");
+
+    expect(swageRule && passClassOD(swageRule, "II", 60.3)).toBe(true);
+    expect(pressRule && passClassOD(pressRule, "II", 60.3)).toBe(false);
   });
 
-  it("valida slip-on por subtipo en Clase II", () => {
-    expect(pass("slip_on_machine_grooved", "II", 48.3)).toBe(true);
-    expect(pass("slip_on_grip", "II", 48.3)).toBe(true);
-    expect(pass("slip_on_slip_type", "II", 48.3)).toBe(true);
+  it("habilita los tres subtipos Slip-on en Clase II dentro de los límites", () => {
+    const mgRule = SUBTYPE_RULES.slip_on_joints.find((rule) => rule.id === "machine_grooved");
+    const gripRule = SUBTYPE_RULES.slip_on_joints.find((rule) => rule.id === "grip");
+    const slipRule = SUBTYPE_RULES.slip_on_joints.find((rule) => rule.id === "slip_type");
+
+    expect(mgRule && passClassOD(mgRule, "II", 60.3)).toBe(true);
+    expect(gripRule && passClassOD(gripRule, "II", 60.3)).toBe(true);
+    expect(slipRule && passClassOD(slipRule, "II", 60.3)).toBe(true);
   });
 
-  it("controla Grip en Clase I por Tabla 12.2.9", () => {
-    expect(pass("slip_on_grip", "I", 48.3)).toBe(false);
-  });
-
-  it("bloquea slip-on en bodegas por cláusula general", () => {
+  it("bloquea Slip-on en bodega por la cláusula 2.12.8", () => {
     const groups = evaluateLRShipsGroups({
       systemId: "hydrocarbon_loading_lines",
       space: "cargo_hold",
       joint: "slip_on_joints",
+      pipeClass: "III",
+      od_mm: 73,
     });
 
     const slipOn = groups.slip_on_joints;
     expect(slipOn.status).toBe("forbidden");
-    expect(slipOn.reasons[0]).toBe(
-      "Slip-on no permitido en bodegas/tanques/espacios no fácilmente accesibles"
-    );
-    expect(slipOn.clauses[0]?.section).toMatch(/§2\.12\.8/);
+    expect(slipOn.clauses?.[0]?.section).toMatch(/§2\.12\.8/);
+  });
+
+  it("rechaza Grip en Clase I por límite de Tabla 12.2.9", () => {
+    const gripRule = SUBTYPE_RULES.slip_on_joints.find((rule) => rule.id === "grip");
+    expect(gripRule && passClassOD(gripRule, "I", 48.3)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- normalize the LR Ships dataset to the 12.2.8 source, including new fire-test tokens and the updated swage coverage
- expose explicit subtype rules in the LR Ships evaluator, refine fire-test/notes handling, and propagate the new class/OD limits
- sync the front-end coupling hints and regression tests with the revised subtype availability rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dee6a04210832186e2040f1bac51f9