### PR TITLE
Revise LR Ships joint evaluation pipeline

### DIFF
--- a/components/JointsGroupCard.tsx
+++ b/components/JointsGroupCard.tsx
@@ -1,0 +1,68 @@
+import { SUBTYPE_RULES, passClassOD } from "../engine/lrShips.js";
+import type { Group, PipeClass } from "../engine/lrShips.js";
+
+type Clause = { code: string; section: string; title: string };
+
+type Evaluation = {
+  status: "allowed" | "conditional" | "forbidden";
+  conditions: string[];
+  reasons: string[];
+  notesApplied: number[];
+  clauses: Clause[];
+};
+
+export type CardTone = "success" | "warning" | "danger";
+
+export type SubtypeState = {
+  id: string;
+  enabled: boolean;
+};
+
+export type JointsGroupCardState = {
+  tone: CardTone;
+  status: Evaluation["status"];
+  conditions: string[];
+  reasons: string[];
+  notes: number[];
+  clauses: Clause[];
+  subtypes: SubtypeState[];
+};
+
+type BuildStateParams = {
+  group: Group;
+  evaluation: Evaluation;
+  pipeClass: PipeClass;
+  od_mm?: number;
+};
+
+export function buildJointsGroupCardState({
+  group,
+  evaluation,
+  pipeClass,
+  od_mm,
+}: BuildStateParams): JointsGroupCardState {
+  const tone: CardTone = evaluation.status === "forbidden"
+    ? "danger"
+    : evaluation.status === "conditional" || evaluation.conditions.length > 0
+    ? "warning"
+    : "success";
+
+  const subtypes = (SUBTYPE_RULES[group] ?? []).map((rule) => ({
+    id: rule.id,
+    enabled: evaluation.status !== "forbidden" && passClassOD(rule, pipeClass, od_mm),
+  }));
+
+  return {
+    tone,
+    status: evaluation.status,
+    conditions: [...evaluation.conditions],
+    reasons: [...evaluation.reasons],
+    notes: [...evaluation.notesApplied],
+    clauses: [...evaluation.clauses],
+    subtypes,
+  };
+}
+
+export function isSubtypeEnabled(state: JointsGroupCardState, subtypeId: string) {
+  return state.subtypes.some((item) => item.id === subtypeId && item.enabled);
+}

--- a/data/lr_ships_mech_joints.ts
+++ b/data/lr_ships_mech_joints.ts
@@ -1,232 +1,127 @@
-export type LRShipsJointGroup = "pipe_unions" | "compression_couplings" | "slip_on_joints";
+export type Group = "pipe_unions" | "compression_couplings" | "slip_on_joints";
 
-export interface LRShipsSystem {
-  id: string;
-  label_es: string;
-  label_en?: string;
-  group?: string;
-  class_of_pipe_system: "dry" | "wet" | "dry/wet";
-  fire_test: "30min_dry" | "30min_wet" | "8+22" | "not_required";
-  notes: number[];
-  allowed_joints: Partial<Record<LRShipsJointGroup, boolean>>;
-}
-
-export interface LRShipsPipeClassRule {
-  joint: Joint;
-  class: PipeClass[];
-  od_max_mm?: Partial<Record<PipeClass, number>>;
-}
-
-export interface LRShipsDataset {
-  standard: "LR_SHIPS";
-  version: string;
-  systems: LRShipsSystem[];
-  pipe_class_rules: LRShipsPipeClassRule[];
-  notes: Record<string, LRShipsNote>;
-}
+export type PipeClass = "I" | "II" | "III";
 
 export type Space =
   | "machinery_cat_A"
+  | "accommodation"
   | "other_machinery"
   | "other_machinery_accessible"
-  | "accommodation"
-  | "pump_room"
-  | "open_deck"
-  | "tank"
   | "cargo_hold"
-  | "cofferdam"
-  | "void";
+  | "tank"
+  | "pump_room"
+  | "open_deck";
 
 export type Joint =
-  | "pipe_unions"
-  | "compression_couplings"
-  | "slip_on_joints"
+  | Group
   | "pipe_union_welded_brazed"
   | "compression_swage"
-  | "compression_typical"
   | "compression_bite"
+  | "compression_typical"
   | "compression_flared"
   | "compression_press"
   | "slip_on_machine_grooved"
   | "slip_on_grip"
   | "slip_on_slip_type";
 
-export type PipeClass = "I" | "II" | "III";
-
-export type LRShipsNote =
-  | {
-      type: "fire_test_if_space";
-      spaces: Space[];
-      test: "from_row" | "30min_dry" | "30min_wet" | "8+22";
-    }
-  | {
-      type: "prohibit_slip_on_in_spaces";
-      prohibit: Space[];
-      allow_if?: "other_machinery_visible_accessible";
-    }
-  | {
-      type: "require_fire_resistant_type_except";
-      except: { space: Space; not_for?: "fuel_oil_lines" };
-    }
-  | { type: "only_above_bulkhead_deck_passenger_ships" }
-  | { type: "allow_slip_type_on_open_deck_max_pressure_bar"; max_bar: number }
-  | {
-      type: "test_equivalence";
-      equivalences: Record<"30min_dry" | "30min_wet" | "8+22", "30min_dry" | "30min_wet" | "8+22">;
-    }
-  | { type: "reference_only"; ref: string };
-
-export const LR_SHIPS_DATASET: LRShipsDataset = {
-  standard: "LR_SHIPS",
-  version: "Pt5 Ch12 Sec2.12 (Tables 12.2.8, 12.2.9) – rev 2024-06",
-  systems: [
-    {
-      id: "ballast_system",
-      label_es: "Sistema de lastre",
-      label_en: "Ballast system",
-      class_of_pipe_system: "wet",
-      fire_test: "30min_wet",
-      notes: [4],
-      allowed_joints: {
-        pipe_unions: true,
-        compression_couplings: true,
-        slip_on_joints: true,
-      },
-    },
-    {
-      id: "bilge_lines",
-      label_es: "Líneas de achique",
-      label_en: "Bilge lines",
-      class_of_pipe_system: "dry/wet",
-      fire_test: "8+22",
-      notes: [4],
-      allowed_joints: {
-        pipe_unions: true,
-        compression_couplings: true,
-        slip_on_joints: true,
-      },
-    },
-    {
-      id: "hydrocarbon_loading_lines",
-      group: "flammable_fluids_fp_le_60",
-      label_es: "Líneas de carga de hidrocarburos",
-      label_en: "Hydrocarbon loading lines",
-      class_of_pipe_system: "dry",
-      fire_test: "30min_dry",
-      notes: [1],
-      allowed_joints: {
-        pipe_unions: true,
-        compression_couplings: true,
-        slip_on_joints: true,
-      },
-    },
-    {
-      id: "seawater_cooling",
-      label_es: "Sistema de enfriamiento por agua de mar",
-      label_en: "Sea water cooling",
-      class_of_pipe_system: "wet",
-      fire_test: "30min_wet",
-      notes: [1, 2],
-      allowed_joints: {
-        pipe_unions: true,
-        compression_couplings: true,
-        slip_on_joints: true,
-      },
-    },
-    {
-      id: "fire_main",
-      label_es: "Red principal de incendios",
-      label_en: "Fire main",
-      class_of_pipe_system: "wet",
-      fire_test: "30min_wet",
-      notes: [1, 2, 3],
-      allowed_joints: {
-        pipe_unions: true,
-        compression_couplings: true,
-        slip_on_joints: true,
-      },
-    },
-    {
-      id: "fuel_oil_system",
-      label_es: "Sistema de fuel oil",
-      label_en: "Fuel oil system",
-      class_of_pipe_system: "dry",
-      fire_test: "30min_dry",
-      notes: [3],
-      allowed_joints: {
-        pipe_unions: true,
-        compression_couplings: true,
-        slip_on_joints: false,
-      },
-    },
-    {
-      id: "sanitary",
-      label_es: "Sistema sanitario",
-      label_en: "Sanitary system",
-      class_of_pipe_system: "wet",
-      fire_test: "not_required",
-      notes: [],
-      allowed_joints: {
-        pipe_unions: true,
-        compression_couplings: true,
-        slip_on_joints: true,
-      },
-    },
-  ],
-  pipe_class_rules: [
-    {
-      joint: "pipe_union_welded_brazed",
-      class: ["I", "II", "III"],
-      od_max_mm: { I: 60.3, II: 60.3 },
-    },
-    { joint: "compression_swage", class: ["I", "II", "III"] },
-    {
-      joint: "compression_bite",
-      class: ["I", "II", "III"],
-      od_max_mm: { I: 60.3, II: 60.3 },
-    },
-    {
-      joint: "compression_typical",
-      class: ["I", "II", "III"],
-      od_max_mm: { I: 60.3, II: 60.3 },
-    },
-    {
-      joint: "compression_flared",
-      class: ["I", "II", "III"],
-      od_max_mm: { I: 60.3, II: 60.3 },
-    },
-    { joint: "compression_press", class: ["III"] },
-    { joint: "slip_on_machine_grooved", class: ["I", "II", "III"] },
-    { joint: "slip_on_grip", class: ["II", "III"] },
-    { joint: "slip_on_slip_type", class: ["II", "III"] },
-  ],
-  notes: {
-    "1": { type: "fire_test_if_space", spaces: ["pump_room", "open_deck"], test: "from_row" },
-    "2": {
-      type: "prohibit_slip_on_in_spaces",
-      prohibit: ["machinery_cat_A", "accommodation"],
-      allow_if: "other_machinery_visible_accessible",
-    },
-    "3": {
-      type: "require_fire_resistant_type_except",
-      except: { space: "open_deck", not_for: "fuel_oil_lines" },
-    },
-    "4": { type: "fire_test_if_space", spaces: ["machinery_cat_A"], test: "from_row" },
-    "5": { type: "only_above_bulkhead_deck_passenger_ships" },
-    "6": { type: "allow_slip_type_on_open_deck_max_pressure_bar", max_bar: 10 },
-    "7": {
-      type: "test_equivalence",
-      equivalences: {
-        "30min_dry": "8+22",
-        "8+22": "30min_dry",
-        "30min_wet": "30min_wet",
-      },
-    },
-    "8": {
-      type: "reference_only",
-      ref: "Pt5 Ch12 2.12.10 (restrained slip-on en cubierta ≤1 MPa, petroleros/quimiqueros)",
-    },
-  },
+export type LrShipRow = {
+  id: string;
+  label_es: string;
+  class_of_pipe_system: "dry" | "wet" | "dry/wet";
+  fire_test: "30min_dry" | "30min_wet" | "8+22" | "not_required";
+  notes: number[];
+  allowed_joints: {
+    pipe_unions: boolean;
+    compression_couplings: boolean;
+    slip_on_joints: boolean;
+  };
 };
 
-export default LR_SHIPS_DATASET;
+export const LR_SHIPS_SYSTEMS: LrShipRow[] = [
+  {
+    id: "ballast_system",
+    label_es: "Sistema de lastre",
+    class_of_pipe_system: "wet",
+    fire_test: "30min_wet",
+    notes: [4],
+    allowed_joints: {
+      pipe_unions: true,
+      compression_couplings: true,
+      slip_on_joints: true,
+    },
+  },
+  {
+    id: "bilge_lines",
+    label_es: "Líneas de achique",
+    class_of_pipe_system: "dry/wet",
+    fire_test: "8+22",
+    notes: [4],
+    allowed_joints: {
+      pipe_unions: true,
+      compression_couplings: true,
+      slip_on_joints: true,
+    },
+  },
+  {
+    id: "hydrocarbon_loading_lines_fp_le_60",
+    label_es: "Líneas de carga de hidrocarburos",
+    class_of_pipe_system: "dry",
+    fire_test: "30min_dry",
+    notes: [1],
+    allowed_joints: {
+      pipe_unions: true,
+      compression_couplings: true,
+      slip_on_joints: true,
+    },
+  },
+  {
+    id: "seawater_cooling",
+    label_es: "Sistema de enfriamiento por agua de mar",
+    class_of_pipe_system: "wet",
+    fire_test: "30min_wet",
+    notes: [1, 2],
+    allowed_joints: {
+      pipe_unions: true,
+      compression_couplings: true,
+      slip_on_joints: true,
+    },
+  },
+  {
+    id: "fire_main",
+    label_es: "Red principal de incendios",
+    class_of_pipe_system: "wet",
+    fire_test: "30min_wet",
+    notes: [1, 2, 3],
+    allowed_joints: {
+      pipe_unions: true,
+      compression_couplings: true,
+      slip_on_joints: true,
+    },
+  },
+  {
+    id: "fuel_oil_system",
+    label_es: "Sistema de fuel oil",
+    class_of_pipe_system: "dry",
+    fire_test: "30min_dry",
+    notes: [3],
+    allowed_joints: {
+      pipe_unions: true,
+      compression_couplings: true,
+      slip_on_joints: false,
+    },
+  },
+  {
+    id: "sanitary",
+    label_es: "Sistema sanitario",
+    class_of_pipe_system: "wet",
+    fire_test: "not_required",
+    notes: [],
+    allowed_joints: {
+      pipe_unions: true,
+      compression_couplings: true,
+      slip_on_joints: true,
+    },
+  },
+];
+
+export const LR_SHIPS_DATA_VERSION = "2024-06-r2";

--- a/dist/data/lr_ships_mech_joints.js
+++ b/dist/data/lr_ships_mech_joints.js
@@ -1,153 +1,87 @@
-export const LR_SHIPS_DATASET = {
-    standard: "LR_SHIPS",
-    version: "Pt5 Ch12 Sec2.12 (Tables 12.2.8, 12.2.9) – rev 2024-06",
-    systems: [
-        {
-            id: "ballast_system",
-            label_es: "Sistema de lastre",
-            label_en: "Ballast system",
-            class_of_pipe_system: "wet",
-            fire_test: "30min_wet",
-            notes: [4],
-            allowed_joints: {
-                pipe_unions: true,
-                compression_couplings: true,
-                slip_on_joints: true,
-            },
-        },
-        {
-            id: "bilge_lines",
-            label_es: "Líneas de achique",
-            label_en: "Bilge lines",
-            class_of_pipe_system: "dry/wet",
-            fire_test: "8+22",
-            notes: [4],
-            allowed_joints: {
-                pipe_unions: true,
-                compression_couplings: true,
-                slip_on_joints: true,
-            },
-        },
-        {
-            id: "hydrocarbon_loading_lines",
-            group: "flammable_fluids_fp_le_60",
-            label_es: "Líneas de carga de hidrocarburos",
-            label_en: "Hydrocarbon loading lines",
-            class_of_pipe_system: "dry",
-            fire_test: "30min_dry",
-            notes: [1],
-            allowed_joints: {
-                pipe_unions: true,
-                compression_couplings: true,
-                slip_on_joints: true,
-            },
-        },
-        {
-            id: "seawater_cooling",
-            label_es: "Sistema de enfriamiento por agua de mar",
-            label_en: "Sea water cooling",
-            class_of_pipe_system: "wet",
-            fire_test: "30min_wet",
-            notes: [1, 2],
-            allowed_joints: {
-                pipe_unions: true,
-                compression_couplings: true,
-                slip_on_joints: true,
-            },
-        },
-        {
-            id: "fire_main",
-            label_es: "Red principal de incendios",
-            label_en: "Fire main",
-            class_of_pipe_system: "wet",
-            fire_test: "30min_wet",
-            notes: [1, 2, 3],
-            allowed_joints: {
-                pipe_unions: true,
-                compression_couplings: true,
-                slip_on_joints: true,
-            },
-        },
-        {
-            id: "fuel_oil_system",
-            label_es: "Sistema de fuel oil",
-            label_en: "Fuel oil system",
-            class_of_pipe_system: "dry",
-            fire_test: "30min_dry",
-            notes: [3],
-            allowed_joints: {
-                pipe_unions: true,
-                compression_couplings: true,
-                slip_on_joints: false,
-            },
-        },
-        {
-            id: "sanitary",
-            label_es: "Sistema sanitario",
-            label_en: "Sanitary system",
-            class_of_pipe_system: "wet",
-            fire_test: "not_required",
-            notes: [],
-            allowed_joints: {
-                pipe_unions: true,
-                compression_couplings: true,
-                slip_on_joints: true,
-            },
-        },
-    ],
-    pipe_class_rules: [
-        {
-            joint: "pipe_union_welded_brazed",
-            class: ["I", "II", "III"],
-            od_max_mm: { I: 60.3, II: 60.3 },
-        },
-        { joint: "compression_swage", class: ["I", "II", "III"] },
-        {
-            joint: "compression_bite",
-            class: ["I", "II", "III"],
-            od_max_mm: { I: 60.3, II: 60.3 },
-        },
-        {
-            joint: "compression_typical",
-            class: ["I", "II", "III"],
-            od_max_mm: { I: 60.3, II: 60.3 },
-        },
-        {
-            joint: "compression_flared",
-            class: ["I", "II", "III"],
-            od_max_mm: { I: 60.3, II: 60.3 },
-        },
-        { joint: "compression_press", class: ["III"] },
-        { joint: "slip_on_machine_grooved", class: ["I", "II", "III"] },
-        { joint: "slip_on_grip", class: ["II", "III"] },
-        { joint: "slip_on_slip_type", class: ["II", "III"] },
-    ],
-    notes: {
-        "1": { type: "fire_test_if_space", spaces: ["pump_room", "open_deck"], test: "from_row" },
-        "2": {
-            type: "prohibit_slip_on_in_spaces",
-            prohibit: ["machinery_cat_A", "accommodation"],
-            allow_if: "other_machinery_visible_accessible",
-        },
-        "3": {
-            type: "require_fire_resistant_type_except",
-            except: { space: "open_deck", not_for: "fuel_oil_lines" },
-        },
-        "4": { type: "fire_test_if_space", spaces: ["machinery_cat_A"], test: "from_row" },
-        "5": { type: "only_above_bulkhead_deck_passenger_ships" },
-        "6": { type: "allow_slip_type_on_open_deck_max_pressure_bar", max_bar: 10 },
-        "7": {
-            type: "test_equivalence",
-            equivalences: {
-                "30min_dry": "8+22",
-                "8+22": "30min_dry",
-                "30min_wet": "30min_wet",
-            },
-        },
-        "8": {
-            type: "reference_only",
-            ref: "Pt5 Ch12 2.12.10 (restrained slip-on en cubierta ≤1 MPa, petroleros/quimiqueros)",
+export const LR_SHIPS_SYSTEMS = [
+    {
+        id: "ballast_system",
+        label_es: "Sistema de lastre",
+        class_of_pipe_system: "wet",
+        fire_test: "30min_wet",
+        notes: [4],
+        allowed_joints: {
+            pipe_unions: true,
+            compression_couplings: true,
+            slip_on_joints: true,
         },
     },
-};
-export default LR_SHIPS_DATASET;
+    {
+        id: "bilge_lines",
+        label_es: "Líneas de achique",
+        class_of_pipe_system: "dry/wet",
+        fire_test: "8+22",
+        notes: [4],
+        allowed_joints: {
+            pipe_unions: true,
+            compression_couplings: true,
+            slip_on_joints: true,
+        },
+    },
+    {
+        id: "hydrocarbon_loading_lines_fp_le_60",
+        label_es: "Líneas de carga de hidrocarburos",
+        class_of_pipe_system: "dry",
+        fire_test: "30min_dry",
+        notes: [1],
+        allowed_joints: {
+            pipe_unions: true,
+            compression_couplings: true,
+            slip_on_joints: true,
+        },
+    },
+    {
+        id: "seawater_cooling",
+        label_es: "Sistema de enfriamiento por agua de mar",
+        class_of_pipe_system: "wet",
+        fire_test: "30min_wet",
+        notes: [1, 2],
+        allowed_joints: {
+            pipe_unions: true,
+            compression_couplings: true,
+            slip_on_joints: true,
+        },
+    },
+    {
+        id: "fire_main",
+        label_es: "Red principal de incendios",
+        class_of_pipe_system: "wet",
+        fire_test: "30min_wet",
+        notes: [1, 2, 3],
+        allowed_joints: {
+            pipe_unions: true,
+            compression_couplings: true,
+            slip_on_joints: true,
+        },
+    },
+    {
+        id: "fuel_oil_system",
+        label_es: "Sistema de fuel oil",
+        class_of_pipe_system: "dry",
+        fire_test: "30min_dry",
+        notes: [3],
+        allowed_joints: {
+            pipe_unions: true,
+            compression_couplings: true,
+            slip_on_joints: false,
+        },
+    },
+    {
+        id: "sanitary",
+        label_es: "Sistema sanitario",
+        class_of_pipe_system: "wet",
+        fire_test: "not_required",
+        notes: [],
+        allowed_joints: {
+            pipe_unions: true,
+            compression_couplings: true,
+            slip_on_joints: true,
+        },
+    },
+];
+export const LR_SHIPS_DATA_VERSION = "2024-06-r2";

--- a/dist/engine/lrShips.js
+++ b/dist/engine/lrShips.js
@@ -1,443 +1,175 @@
-import dataset from "../data/lr_ships_mech_joints.js";
+import { LR_SHIPS_SYSTEMS } from "../data/lr_ships_mech_joints.js";
 export const SUBTYPE_RULES = {
     pipe_unions: [
-        {
-            id: "welded_brazed",
-            joint: "pipe_union_welded_brazed",
-            classes: ["I", "II", "III"],
-            od_max_mm: { I: 60.3, II: 60.3 },
-        },
+        { id: "welded_brazed", classes: ["I", "II", "III"], od_max_mm: { I: 60.3, II: 60.3 } },
     ],
     compression_couplings: [
-        { id: "swage", joint: "compression_swage", classes: ["I", "II", "III"] },
-        {
-            id: "bite",
-            joint: "compression_bite",
-            classes: ["I", "II", "III"],
-            od_max_mm: { I: 60.3, II: 60.3 },
-        },
-        {
-            id: "typical",
-            joint: "compression_typical",
-            classes: ["I", "II", "III"],
-            od_max_mm: { I: 60.3, II: 60.3 },
-        },
-        {
-            id: "flared",
-            joint: "compression_flared",
-            classes: ["I", "II", "III"],
-            od_max_mm: { I: 60.3, II: 60.3 },
-        },
-        { id: "press", joint: "compression_press", classes: ["III"] },
+        { id: "swage", classes: ["I", "II", "III"] },
+        { id: "bite", classes: ["I", "II", "III"], od_max_mm: { I: 60.3, II: 60.3 } },
+        { id: "typical", classes: ["I", "II", "III"], od_max_mm: { I: 60.3, II: 60.3 } },
+        { id: "flared", classes: ["I", "II", "III"], od_max_mm: { I: 60.3, II: 60.3 } },
+        { id: "press", classes: ["III"] },
     ],
     slip_on_joints: [
-        {
-            id: "machine_grooved",
-            joint: "slip_on_machine_grooved",
-            classes: ["I", "II", "III"],
-        },
-        { id: "grip", joint: "slip_on_grip", classes: ["II", "III"] },
-        { id: "slip_type", joint: "slip_on_slip_type", classes: ["II", "III"] },
+        { id: "machine_grooved", classes: ["I", "II", "III"] },
+        { id: "grip", classes: ["II", "III"] },
+        { id: "slip_type", classes: ["II", "III"] },
     ],
 };
-const normReference = "LR Ships Pt5 Ch12 §2.12, Tablas 12.2.8–12.2.9";
-function normalizeLRShipsContext(ctx) {
-    const mediumSame = ctx.mediumInPipeSameAsTank ?? ctx.sameMediumInTank ?? true;
-    return {
-        ...ctx,
-        accessibility: ctx.accessibility ?? "easy",
-        location: ctx.location ?? "visible_accessible",
-        mediumInPipeSameAsTank: mediumSame,
-        sameMediumInTank: ctx.sameMediumInTank ?? mediumSame,
-        directToShipSideBelowLimit: ctx.directToShipSideBelowLimit ?? false,
-        asMainMeans: ctx.asMainMeans ?? false,
-    };
+export function passClassOD(rule, cls, od_mm) {
+    if (!rule.classes.includes(cls))
+        return false;
+    const lim = rule.od_max_mm?.[cls];
+    return lim ? (od_mm ?? Infinity) <= lim : true;
 }
-export function evaluateLRShips(ctx, db = dataset) {
-    const normalizedCtx = normalizeLRShipsContext(ctx);
-    const sys = db.systems.find((s) => s.id === normalizedCtx.systemId);
-    if (!sys) {
-        return forbid(normalizedCtx, [], "Sistema no reconocido");
-    }
-    const jointGroup = groupOf(normalizedCtx.joint);
-    if (!jointGroup) {
-        return forbid(normalizedCtx, [], "Tipo de junta desconocido");
-    }
-    const groups = evaluateGroupsForRow(normalizedCtx, sys, db);
-    const groupResult = groups[jointGroup];
-    const trace = [...groupResult.trace];
-    const conditions = [...groupResult.conditions];
-    const notesApplied = [...groupResult.notesApplied];
-    const clauses = [...groupResult.clauses];
-    const reasons = [...groupResult.reasons];
-    let status = groupResult.status;
-    let reason = reasons.length ? reasons[reasons.length - 1] : undefined;
-    if (status !== "forbidden") {
-        const rulesForJoint = collectRulesForJoint(normalizedCtx.joint);
-        if (rulesForJoint.length) {
-            const pipeClass = normalizedCtx.pipeClass;
-            const odValue = typeof normalizedCtx.od_mm === "number" ? normalizedCtx.od_mm : undefined;
-            if (!pipeClass) {
-                reason = "Falta clase/OD para aplicar Tabla 12.2.9";
-                status = "forbidden";
-                pushOnce(reasons, reason);
-            }
-            else {
-                let detail = null;
-                let anySubtypeOk = false;
-                let missingInputs = false;
-                for (const rule of rulesForJoint) {
-                    const limit = rule.od_max_mm?.[pipeClass];
-                    if (limit != null && odValue === undefined) {
-                        missingInputs = true;
-                        continue;
-                    }
-                    if (passClassOD(rule, pipeClass, odValue)) {
-                        anySubtypeOk = true;
-                        detail = formatRuleDetail(rule, pipeClass);
-                        break;
-                    }
-                }
-                if (!anySubtypeOk) {
-                    reason = missingInputs
-                        ? "Falta clase/OD para aplicar Tabla 12.2.9"
-                        : "Tabla 12.2.9: límite de clase/OD";
-                    status = "forbidden";
-                    pushOnce(reasons, reason);
-                }
-                if (detail) {
-                    trace.push(detail);
-                }
-            }
-        }
-    }
-    const observations = Array.from(new Set([...conditions, ...reasons]));
-    return {
-        status,
-        conditions,
-        reasons,
-        normRef: normReference,
-        reason,
-        systemId: sys.id,
-        joint: normalizedCtx.joint,
-        pipeClass: normalizedCtx.pipeClass,
-        od_mm: normalizedCtx.od_mm,
-        designPressure_bar: normalizedCtx.designPressure_bar,
-        trace,
-        observations,
-        notesApplied,
-        clauses,
+export function evaluateLRShips(ctx) {
+    const row = findRow(ctx.systemId);
+    const out = {
+        pipe_unions: base(),
+        compression_couplings: base(),
+        slip_on_joints: base(),
     };
-}
-export function evaluateGroups(ctx, db = dataset) {
-    const normalizedCtx = normalizeLRShipsContext(ctx);
-    const row = db.systems.find((s) => s.id === normalizedCtx.systemId);
     if (!row) {
-        throw new Error("Sistema no reconocido");
+        return forbidAll("Fila 12.2.8 no encontrada");
     }
-    return evaluateGroupsForRow(normalizedCtx, row, db);
+    for (const group of Object.keys(out)) {
+        if (!row.allowed_joints[group]) {
+            block(out[group], "Tabla 12.2.8: ‘−’ para este tipo de unión");
+        }
+    }
+    const fireLabel = labelFire(row.fire_test);
+    if (fireLabel) {
+        forEachOpen(out, (ev) => makeConditional(ev, fireLabel));
+    }
+    applyRowNotes(ctx, row, out);
+    applyClauses(ctx, out);
+    applySubtypeLimits(ctx, out);
+    return out;
 }
-function evaluateGroupsForRow(ctx, row, db) {
-    const groups = {
-        pipe_unions: base(Boolean(row.allowed_joints.pipe_unions), row, "pipe_unions"),
-        compression_couplings: base(Boolean(row.allowed_joints.compression_couplings), row, "compression_couplings"),
-        slip_on_joints: base(Boolean(row.allowed_joints.slip_on_joints), row, "slip_on_joints"),
-    };
-    const rowNotes = new Set(row?.notes ?? []);
-    const fireTestLabel = labelFire(row.fire_test);
-    if (fireTestLabel) {
-        for (const result of Object.values(groups)) {
-            if (result.status === "forbidden")
-                continue;
-            result.status = "conditional";
-            pushOnce(result.conditions, fireTestLabel);
-            pushOnce(result.trace, `Tabla 12.2.8: Ensayo base ${fireTestLabel}.`);
-        }
-    }
-    for (const note of rowNotes) {
-        for (const [groupName, result] of Object.entries(groups)) {
-            if (result.status === "forbidden")
-                continue;
-            if (!Boolean(row.allowed_joints[groupName]))
-                continue;
-            if (note === 1) {
-                if (ctx.space === "pump_room" || ctx.space === "open_deck") {
-                    if (fireTestLabel) {
-                        result.status = "conditional";
-                        pushOnce(result.conditions, fireTestLabel);
-                        pushOnce(result.notesApplied, note);
-                        pushOnce(result.trace, `Nota 1: espacio ${ctx.space} ⇒ ${fireTestLabel}.`);
-                    }
-                }
-                continue;
-            }
-            applyNote_LRShips(ctx, note, groupName, result);
-        }
-    }
-    for (const [groupName, result] of Object.entries(groups)) {
-        if (result.status === "forbidden")
-            continue;
-        applyGeneralClauses(ctx, groupName, result);
-    }
-    const pipeClass = ctx.pipeClass;
-    const odValue = typeof ctx.od_mm === "number" ? ctx.od_mm : undefined;
-    if (pipeClass) {
-        for (const [groupName, result] of Object.entries(groups)) {
-            const subtypeRules = SUBTYPE_RULES[groupName] ?? [];
-            if (!subtypeRules.length)
-                continue;
-            let anySubtypeOk = false;
-            let missingInputs = false;
-            for (const rule of subtypeRules) {
-                const limit = rule.od_max_mm?.[pipeClass];
-                if (limit != null && odValue === undefined) {
-                    missingInputs = true;
-                    continue;
-                }
-                if (passClassOD(rule, pipeClass, odValue)) {
-                    anySubtypeOk = true;
-                    break;
-                }
-            }
-            if (!anySubtypeOk && !missingInputs) {
-                result.status = "forbidden";
-                pushOnce(result.reasons, "Tabla 12.2.9: ningún subtipo cumple clase/OD");
-            }
-        }
-    }
-    return groups;
+function findRow(id) {
+    return LR_SHIPS_SYSTEMS.find((row) => row.id === id);
 }
-function base(allowed, row, group) {
+function base() {
+    return { status: "allowed", conditions: [], reasons: [], notesApplied: [], clauses: [] };
+}
+function block(ev, reason) {
+    ev.status = "forbidden";
+    pushUnique(ev.reasons, reason);
+}
+function makeConditional(ev, condition) {
+    if (ev.status === "forbidden")
+        return;
+    if (ev.status !== "conditional") {
+        ev.status = "conditional";
+    }
+    pushUnique(ev.conditions, condition);
+}
+function pushUnique(arr, value) {
+    if (!arr.includes(value))
+        arr.push(value);
+}
+function note(ev, n) {
+    if (!ev.notesApplied.includes(n)) {
+        ev.notesApplied.push(n);
+    }
+}
+function noteAll(out, n) {
+    for (const group of Object.keys(out)) {
+        note(out[group], n);
+    }
+}
+function forEachOpen(out, fn) {
+    for (const group of Object.keys(out)) {
+        const ev = out[group];
+        if (ev.status !== "forbidden") {
+            fn(ev);
+        }
+    }
+}
+function forbidAll(reason) {
     const result = {
-        status: allowed ? "allowed" : "forbidden",
-        conditions: [],
-        reasons: [],
-        notesApplied: [],
-        clauses: [],
-        trace: [],
+        pipe_unions: base(),
+        compression_couplings: base(),
+        slip_on_joints: base(),
     };
-    const baseMessage = `Tabla 12.2.8 (${row.label_es}): ${allowed ? "+" : "–"} para ${describeJointGroup(group)}; clasificación '${row.class_of_pipe_system}'.`;
-    result.trace.push(baseMessage);
-    if (!allowed) {
-        result.reasons.push(`Tabla 12.2.8: la fila indica ‘-’ para ${describeJointGroup(group)}`);
+    for (const group of Object.keys(result)) {
+        block(result[group], reason);
     }
     return result;
 }
-function pushOnce(arr, value) {
-    if (value === undefined || value === null)
-        return;
-    if (!arr.includes(value)) {
-        arr.push(value);
-    }
-}
-function forbidByClause(out, msg, clause) {
-    out.status = "forbidden";
-    pushOnce(out.reasons, msg);
-    if (!out.clauses) {
-        out.clauses = [];
-    }
-    out.clauses.push(clause);
-}
-function applyNote_LRShips(ctx, note, group, out) {
-    switch (note) {
-        case 2: {
-            if (group !== "slip_on_joints")
-                break;
-            if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
-                out.status = "forbidden";
-                pushOnce(out.reasons, "Nota 2: Slip-on prohibidas en Cat. A / alojamientos");
-                pushOnce(out.notesApplied, note);
-                pushOnce(out.trace, `Nota 2: Slip-on prohibidas en ${ctx.space}.`);
-            }
-            else if ((ctx.space === "other_machinery" || ctx.space === "other_machinery_accessible") &&
-                ctx.location !== "visible_accessible") {
-                out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-                pushOnce(out.conditions, "Ubicar en posición visible/accesible (Nota 2)");
-                pushOnce(out.notesApplied, note);
-                pushOnce(out.trace, "Nota 2: exigir ubicación visible/accesible en otras máquinas.");
-            }
-            break;
-        }
-        case 4: {
-            if (ctx.space === "machinery_cat_A") {
-                out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-                pushOnce(out.conditions, "Ensayo adicional en Cat. A (Nota 4)");
-                pushOnce(out.notesApplied, note);
-                pushOnce(out.trace, "Nota 4: Cat. A ⇒ ensayo de fuego específico.");
-            }
-            break;
-        }
-        case 3: {
-            if (ctx.space !== "open_deck") {
-                out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-                pushOnce(out.conditions, "Junta de tipo resistente al fuego (Nota 3)");
-                pushOnce(out.notesApplied, note);
-                pushOnce(out.trace, "Nota 3: exigir junta de tipo resistente al fuego.");
-            }
-            break;
-        }
-        case 5: {
-            if (ctx.space !== "open_deck") {
-                out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-                pushOnce(out.conditions, "Sólo sobre cubierta de francobordo (buques de pasaje)");
-                pushOnce(out.notesApplied, note);
-                pushOnce(out.trace, "Nota 5: restringir a cubierta de francobordo en buques de pasaje.");
-            }
-            break;
-        }
-        case 6: {
-            if (ctx.joint === "slip_on_slip_type" && ctx.space === "open_deck") {
-                const maxPressure = ctx.designPressure_bar ?? Number.POSITIVE_INFINITY;
-                if (maxPressure <= 10) {
-                    out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-                    pushOnce(out.conditions, "Slip-type ≤10 bar en cubierta expuesta");
-                    pushOnce(out.trace, "Nota 6: Slip-type permitido ≤10 bar en cubierta expuesta.");
-                }
-                else {
-                    out.status = "forbidden";
-                    pushOnce(out.reasons, "Nota 6: Slip-type >10 bar prohibido");
-                    pushOnce(out.trace, "Nota 6: Slip-type excede 10 bar ⇒ prohibido.");
-                }
-                pushOnce(out.notesApplied, note);
-            }
-            break;
-        }
-        case 7: {
-            pushOnce(out.trace, "Nota 7: revisar equivalencias de ensayo.");
-            break;
-        }
-        case 8: {
-            pushOnce(out.trace, "Nota 8: ver §2.12.10 para slip-on restringidas.");
-            break;
-        }
-    }
-}
-function applyGeneralClauses(ctx, group, out) {
-    if (out.status === "forbidden") {
-        return;
-    }
-    const isCargoOrTank = ctx.space === "cargo_hold" || ctx.space === "tank";
-    const isHardAccess = ctx.accessibility === "not_easy";
-    if (group === "slip_on_joints" && (isCargoOrTank || isHardAccess)) {
-        forbidByClause(out, "Slip-on no permitido en bodegas/tanques/espacios no fácilmente accesibles", {
-            code: "SH-2.12.8",
-            title: "Slip-on no en bodegas/tanques/espacios no fácilmente accesibles",
-            section: "Pt 5, Ch 12, §2.12.8",
-        });
-    }
-    if (group === "slip_on_joints" && ctx.space === "tank" && ctx.mediumInPipeSameAsTank === false) {
-        forbidByClause(out, "Slip-on dentro de tanque: permitido sólo si el medio es el mismo", {
-            code: "SH-2.12.8.b",
-            title: "Medio en tanque debe ser el mismo",
-            section: "Pt 5, Ch 12, §2.12.8",
-        });
-    }
-    const subtype = ctx.subtype ?? ctx.joint;
-    if ((subtype === "slip_on_slip_type" || subtype === "slip_type") && ctx.asMainMeans) {
-        forbidByClause(out, "Slip-type no como medio principal (sólo compensación axial)", {
-            code: "SH-2.12.9",
-            title: "Slip type: no como medio principal",
-            section: "Pt 5, Ch 12, §2.12.9",
-        });
-    }
-    if (ctx.directToShipSideBelowLimit || ctx.tankContainsFlammable) {
-        forbidByClause(out, "Prohibido en conexión directa al costado bajo el límite / tanques con fluidos inflamables", {
-            code: "SH-2.12.5",
-            title: "Riesgo de incendio/inundación",
-            section: "Pt 5, Ch 12, §2.12.5",
-        });
-    }
-}
-function forbid(ctx, trace, message) {
-    return {
-        status: "forbidden",
-        conditions: [],
-        reasons: [message],
-        normRef: normReference,
-        reason: message,
-        systemId: ctx.systemId,
-        joint: ctx.joint,
-        pipeClass: ctx.pipeClass,
-        od_mm: ctx.od_mm,
-        designPressure_bar: ctx.designPressure_bar,
-        trace: [...trace],
-        observations: [message],
-        notesApplied: [],
-        clauses: [],
-    };
-}
-function groupOf(joint) {
-    if (joint === "pipe_unions" || joint === "compression_couplings" || joint === "slip_on_joints") {
-        return joint;
-    }
-    if (joint === "pipe_union_welded_brazed")
-        return "pipe_unions";
-    if (joint === "compression_swage" ||
-        joint === "compression_typical" ||
-        joint === "compression_bite" ||
-        joint === "compression_flared" ||
-        joint === "compression_press") {
-        return "compression_couplings";
-    }
-    if (joint === "slip_on_machine_grooved" ||
-        joint === "slip_on_grip" ||
-        joint === "slip_on_slip_type") {
-        return "slip_on_joints";
-    }
-    return null;
-}
-function labelFire(value) {
-    switch (value) {
+function labelFire(test) {
+    switch (test) {
         case "30min_dry":
             return "30 min seco";
         case "30min_wet":
             return "30 min húmedo";
         case "8+22":
             return "8 min seco + 22 min húmedo";
-        case "not_required":
         default:
             return null;
     }
 }
-function describeJointGroup(group) {
-    switch (group) {
-        case "pipe_unions":
-            return "pipe unions";
-        case "compression_couplings":
-            return "compression couplings";
-        case "slip_on_joints":
-            return "slip-on joints";
+function applyRowNotes(ctx, row, out) {
+    if (!row.notes.length)
+        return;
+    if (row.notes.includes(2)) {
+        const ev = out.slip_on_joints;
+        if (ev.status !== "forbidden") {
+            if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
+                block(ev, "Nota 2: Slip-on no aceptadas en Cat. A / alojamientos");
+            }
+            else if (ctx.space === "other_machinery_accessible") {
+                makeConditional(ev, "Ubicar en posición visible/accesible (MSC/Circ.734)");
+            }
+            note(ev, 2);
+        }
+    }
+    if (row.notes.includes(3) && ctx.space !== "open_deck") {
+        forEachOpen(out, (ev) => makeConditional(ev, "Junta de tipo resistente al fuego"));
+        noteAll(out, 3);
+    }
+    if (row.notes.includes(4) && ctx.space === "machinery_cat_A") {
+        forEachOpen(out, (ev) => makeConditional(ev, "Ensayo adicional en Cat. A (Nota 4)"));
+        noteAll(out, 4);
     }
 }
-function collectRulesForJoint(joint) {
-    const group = groupOf(joint);
-    if (!group) {
-        return [];
+function applyClauses(ctx, out) {
+    const addClause = (ev, code, section, title, reason) => {
+        block(ev, reason);
+        ev.clauses.push({ code, section, title });
+    };
+    const slip = out.slip_on_joints;
+    if (slip.status !== "forbidden") {
+        const hardAccess = ctx.space === "cargo_hold" || ctx.space === "tank" || ctx.accessibility === "not_easy";
+        if (hardAccess) {
+            addClause(slip, "SH-2.12.8", "Pt 5, Ch 12, §2.12.8", "Accesibilidad Slip-on", "Slip-on no permitido en bodegas/tanques/espacios no fácilmente accesibles");
+        }
+        else if (ctx.space === "tank" && ctx.mediumInPipeSameAsTank === false) {
+            addClause(slip, "SH-2.12.8.b", "Pt 5, Ch 12, §2.12.8", "Medio en tanque", "Slip-on dentro de tanque: permitido sólo si el medio es el mismo");
+        }
     }
-    const rules = SUBTYPE_RULES[group] ?? [];
-    if (joint === group) {
-        return rules;
+    if (ctx.asMainMeans && out.slip_on_joints.status !== "forbidden") {
+        addClause(out.slip_on_joints, "SH-2.12.9", "Pt 5, Ch 12, §2.12.9", "Slip-type principal", "Slip-type no puede ser medio principal");
     }
-    return rules.filter((rule) => rule.joint === joint);
+    const hazard = Boolean(ctx.directToShipSideBelowLimit || ctx.tankContainsFlammable);
+    if (hazard) {
+        forEachOpen(out, (ev) => addClause(ev, "SH-2.12.5", "Pt 5, Ch 12, §2.12.5", "Riesgo de incendio/inundación", "Prohibido por riesgo de incendio/inundación"));
+    }
 }
-export function passClassOD(rule, pipeClass, odMM) {
-    if (!rule.classes.includes(pipeClass)) {
-        return false;
+function applySubtypeLimits(ctx, out) {
+    const cls = ctx.pipeClass;
+    if (!cls) {
+        forEachOpen(out, (ev) => block(ev, "Tabla 12.2.9: requiere clase/OD"));
+        return;
     }
-    const limit = rule.od_max_mm?.[pipeClass];
-    if (limit == null) {
-        return true;
+    for (const group of Object.keys(out)) {
+        const ev = out[group];
+        if (ev.status === "forbidden")
+            continue;
+        const rules = SUBTYPE_RULES[group] ?? [];
+        const anyOk = rules.some((rule) => passClassOD(rule, cls, ctx.od_mm));
+        if (!anyOk) {
+            block(ev, "Tabla 12.2.9: ningún subtipo cumple clase/OD");
+        }
     }
-    if (odMM === undefined) {
-        return false;
-    }
-    return odMM <= limit;
 }
-function formatRuleDetail(rule, pipeClass) {
-    const limit = rule.od_max_mm?.[pipeClass];
-    if (limit == null) {
-        return `Tabla 12.2.9: Clase ${pipeClass}`;
-    }
-    return `Tabla 12.2.9: Clase ${pipeClass} con OD ≤ ${limit} mm`;
-}
-export default evaluateLRShips;

--- a/engine/lrShips.ts
+++ b/engine/lrShips.ts
@@ -1,585 +1,260 @@
-import dataset, {
-  LRShipsDataset,
-  LRShipsJointGroup,
-  LRShipsSystem,
-  Space,
-  Joint,
-  PipeClass,
-} from "../data/lr_ships_mech_joints.js";
-import type { ClauseRef, EvalResult, EvalStatus } from "./evalTypes.js";
+import { LR_SHIPS_SYSTEMS } from "../data/lr_ships_mech_joints.js";
+import type { Group, LrShipRow, PipeClass, Space } from "../data/lr_ships_mech_joints.js";
 
-export type { Space, Joint, PipeClass } from "../data/lr_ships_mech_joints.js";
+export type { Space, PipeClass, Group } from "../data/lr_ships_mech_joints.js";
 
-type Group = "pipe_unions" | "compression_couplings" | "slip_on_joints";
+type Status = "allowed" | "conditional" | "forbidden";
 
-type SubtypeJoint = Exclude<Joint, Group>;
+type Eval = {
+  status: Status;
+  conditions: string[];
+  reasons: string[];
+  notesApplied: number[];
+  clauses: { code: string; section: string; title: string }[];
+};
 
-export interface LRShipsSubtypeRule {
+type Ctx = {
+  systemId: string;
+  pipeClass: PipeClass;
+  od_mm: number;
+  space: Space;
+  accessibility?: "easy" | "not_easy";
+  mediumInPipeSameAsTank?: boolean;
+  asMainMeans?: boolean;
+  directToShipSideBelowLimit?: boolean;
+  tankContainsFlammable?: boolean;
+};
+
+type SubtypeRule = {
   id: string;
-  joint: SubtypeJoint;
   classes: PipeClass[];
   od_max_mm?: Partial<Record<PipeClass, number>>;
-}
+};
 
-export const SUBTYPE_RULES: Record<Group, LRShipsSubtypeRule[]> = {
+export const SUBTYPE_RULES: Record<Group, SubtypeRule[]> = {
   pipe_unions: [
-    {
-      id: "welded_brazed",
-      joint: "pipe_union_welded_brazed",
-      classes: ["I", "II", "III"],
-      od_max_mm: { I: 60.3, II: 60.3 },
-    },
+    { id: "welded_brazed", classes: ["I", "II", "III"], od_max_mm: { I: 60.3, II: 60.3 } },
   ],
   compression_couplings: [
-    { id: "swage", joint: "compression_swage", classes: ["I", "II", "III"] },
-    {
-      id: "bite",
-      joint: "compression_bite",
-      classes: ["I", "II", "III"],
-      od_max_mm: { I: 60.3, II: 60.3 },
-    },
-    {
-      id: "typical",
-      joint: "compression_typical",
-      classes: ["I", "II", "III"],
-      od_max_mm: { I: 60.3, II: 60.3 },
-    },
-    {
-      id: "flared",
-      joint: "compression_flared",
-      classes: ["I", "II", "III"],
-      od_max_mm: { I: 60.3, II: 60.3 },
-    },
-    { id: "press", joint: "compression_press", classes: ["III"] },
+    { id: "swage", classes: ["I", "II", "III"] },
+    { id: "bite", classes: ["I", "II", "III"], od_max_mm: { I: 60.3, II: 60.3 } },
+    { id: "typical", classes: ["I", "II", "III"], od_max_mm: { I: 60.3, II: 60.3 } },
+    { id: "flared", classes: ["I", "II", "III"], od_max_mm: { I: 60.3, II: 60.3 } },
+    { id: "press", classes: ["III"] },
   ],
   slip_on_joints: [
-    {
-      id: "machine_grooved",
-      joint: "slip_on_machine_grooved",
-      classes: ["I", "II", "III"],
-    },
-    { id: "grip", joint: "slip_on_grip", classes: ["II", "III"] },
-    { id: "slip_type", joint: "slip_on_slip_type", classes: ["II", "III"] },
+    { id: "machine_grooved", classes: ["I", "II", "III"] },
+    { id: "grip", classes: ["II", "III"] },
+    { id: "slip_type", classes: ["II", "III"] },
   ],
 };
 
-interface GroupEvalResult extends EvalResult {
-  clauses: ClauseRef[];
-  notesApplied: number[];
-  trace: string[];
+export function passClassOD(rule: SubtypeRule, cls: PipeClass, od_mm?: number) {
+  if (!rule.classes.includes(cls)) return false;
+  const lim = rule.od_max_mm?.[cls];
+  return lim ? (od_mm ?? Infinity) <= lim : true;
 }
 
-export interface LRShipsContext {
-  systemId: string;
-  space: Space;
-  joint: Joint;
-  pipeClass?: PipeClass;
-  od_mm?: number;
-  designPressure_bar?: number;
-  lineType?: "fuel_oil" | "thermal_oil" | "other";
-  location?: "visible_accessible" | "normal" | "hidden";
-  sameMediumInTank?: boolean;
-  mediumInPipeSameAsTank?: boolean;
-  accessibility?: "easy" | "not_easy";
-  directToShipSideBelowLimit?: boolean;
-  tankContainsFlammable?: boolean;
-  asMainMeans?: boolean;
-  subtype?: Joint | string;
-}
-
-export interface LRShipsEvaluation {
-  status: EvalStatus;
-  conditions: string[];
-  reasons: string[];
-  normRef: string;
-  reason?: string;
-  systemId: string;
-  joint: Joint;
-  pipeClass?: PipeClass;
-  od_mm?: number;
-  designPressure_bar?: number;
-  trace: string[];
-  observations: string[];
-  notesApplied: number[];
-  clauses: ClauseRef[];
-}
-
-const normReference = "LR Ships Pt5 Ch12 §2.12, Tablas 12.2.8–12.2.9";
-
-function normalizeLRShipsContext(ctx: LRShipsContext): LRShipsContext {
-  const mediumSame = ctx.mediumInPipeSameAsTank ?? ctx.sameMediumInTank ?? true;
-  return {
-    ...ctx,
-    accessibility: ctx.accessibility ?? "easy",
-    location: ctx.location ?? "visible_accessible",
-    mediumInPipeSameAsTank: mediumSame,
-    sameMediumInTank: ctx.sameMediumInTank ?? mediumSame,
-    directToShipSideBelowLimit: ctx.directToShipSideBelowLimit ?? false,
-    asMainMeans: ctx.asMainMeans ?? false,
+export function evaluateLRShips(ctx: Ctx): Record<Group, Eval> {
+  const row = findRow(ctx.systemId);
+  const out: Record<Group, Eval> = {
+    pipe_unions: base(),
+    compression_couplings: base(),
+    slip_on_joints: base(),
   };
-}
 
-export function evaluateLRShips(ctx: LRShipsContext, db: LRShipsDataset = dataset): LRShipsEvaluation {
-  const normalizedCtx = normalizeLRShipsContext(ctx);
-  const sys = db.systems.find((s) => s.id === normalizedCtx.systemId);
-  if (!sys) {
-    return forbid(normalizedCtx, [], "Sistema no reconocido");
-  }
-
-  const jointGroup = groupOf(normalizedCtx.joint);
-  if (!jointGroup) {
-    return forbid(normalizedCtx, [], "Tipo de junta desconocido");
-  }
-
-  const groups = evaluateGroupsForRow(normalizedCtx, sys, db);
-  const groupResult = groups[jointGroup];
-  const trace = [...groupResult.trace];
-  const conditions = [...groupResult.conditions];
-  const notesApplied = [...groupResult.notesApplied];
-  const clauses = [...groupResult.clauses];
-  const reasons = [...groupResult.reasons];
-
-  let status: EvalStatus = groupResult.status;
-  let reason = reasons.length ? reasons[reasons.length - 1] : undefined;
-
-  if (status !== "forbidden") {
-    const rulesForJoint = collectRulesForJoint(normalizedCtx.joint);
-    if (rulesForJoint.length) {
-      const pipeClass = normalizedCtx.pipeClass;
-      const odValue = typeof normalizedCtx.od_mm === "number" ? normalizedCtx.od_mm : undefined;
-
-      if (!pipeClass) {
-        reason = "Falta clase/OD para aplicar Tabla 12.2.9";
-        status = "forbidden";
-        pushOnce(reasons, reason);
-      } else {
-        let detail: string | null = null;
-        let anySubtypeOk = false;
-        let missingInputs = false;
-
-        for (const rule of rulesForJoint) {
-          const limit = rule.od_max_mm?.[pipeClass];
-          if (limit != null && odValue === undefined) {
-            missingInputs = true;
-            continue;
-          }
-          if (passClassOD(rule, pipeClass, odValue)) {
-            anySubtypeOk = true;
-            detail = formatRuleDetail(rule, pipeClass);
-            break;
-          }
-        }
-
-        if (!anySubtypeOk) {
-          reason = missingInputs
-            ? "Falta clase/OD para aplicar Tabla 12.2.9"
-            : "Tabla 12.2.9: límite de clase/OD";
-          status = "forbidden";
-          pushOnce(reasons, reason);
-        }
-
-        if (detail) {
-          trace.push(detail);
-        }
-      }
-    }
-  }
-
-  const observations = Array.from(new Set([...conditions, ...reasons]));
-
-  return {
-    status,
-    conditions,
-    reasons,
-    normRef: normReference,
-    reason,
-    systemId: sys.id,
-    joint: normalizedCtx.joint,
-    pipeClass: normalizedCtx.pipeClass,
-    od_mm: normalizedCtx.od_mm,
-    designPressure_bar: normalizedCtx.designPressure_bar,
-    trace,
-    observations,
-    notesApplied,
-    clauses,
-  };
-}
-
-export function evaluateGroups(ctx: LRShipsContext, db: LRShipsDataset = dataset): Record<Group, GroupEvalResult> {
-  const normalizedCtx = normalizeLRShipsContext(ctx);
-  const row = db.systems.find((s) => s.id === normalizedCtx.systemId);
   if (!row) {
-    throw new Error("Sistema no reconocido");
+    return forbidAll("Fila 12.2.8 no encontrada");
   }
-  return evaluateGroupsForRow(normalizedCtx, row, db);
+
+  for (const group of Object.keys(out) as Group[]) {
+    if (!row.allowed_joints[group]) {
+      block(out[group], "Tabla 12.2.8: ‘−’ para este tipo de unión");
+    }
+  }
+
+  const fireLabel = labelFire(row.fire_test);
+  if (fireLabel) {
+    forEachOpen(out, (ev) => makeConditional(ev, fireLabel));
+  }
+
+  applyRowNotes(ctx, row, out);
+  applyClauses(ctx, out);
+  applySubtypeLimits(ctx, out);
+
+  return out;
 }
 
-function evaluateGroupsForRow(
-  ctx: LRShipsContext,
-  row: LRShipsSystem,
-  db: LRShipsDataset
-): Record<Group, GroupEvalResult> {
-  const groups: Record<Group, GroupEvalResult> = {
-    pipe_unions: base(Boolean(row.allowed_joints.pipe_unions), row, "pipe_unions"),
-    compression_couplings: base(Boolean(row.allowed_joints.compression_couplings), row, "compression_couplings"),
-    slip_on_joints: base(Boolean(row.allowed_joints.slip_on_joints), row, "slip_on_joints"),
-  };
-
-  const rowNotes = new Set<number>(row?.notes ?? []);
-  const fireTestLabel = labelFire(row.fire_test);
-
-  if (fireTestLabel) {
-    for (const result of Object.values(groups)) {
-      if (result.status === "forbidden") continue;
-      result.status = "conditional";
-      pushOnce(result.conditions, fireTestLabel);
-      pushOnce(result.trace, `Tabla 12.2.8: Ensayo base ${fireTestLabel}.`);
-    }
-  }
-
-  for (const note of rowNotes) {
-    for (const [groupName, result] of Object.entries(groups) as [Group, GroupEvalResult][]) {
-      if (result.status === "forbidden") continue;
-      if (!Boolean(row.allowed_joints[groupName])) continue;
-
-      if (note === 1) {
-        if (ctx.space === "pump_room" || ctx.space === "open_deck") {
-          if (fireTestLabel) {
-            result.status = "conditional";
-            pushOnce(result.conditions, fireTestLabel);
-            pushOnce(result.notesApplied, note);
-            pushOnce(result.trace, `Nota 1: espacio ${ctx.space} ⇒ ${fireTestLabel}.`);
-          }
-        }
-        continue;
-      }
-
-      applyNote_LRShips(ctx, note, groupName, result);
-    }
-  }
-
-  for (const [groupName, result] of Object.entries(groups) as [Group, GroupEvalResult][]) {
-    if (result.status === "forbidden") continue;
-    applyGeneralClauses(ctx, groupName, result);
-  }
-
-  const pipeClass = ctx.pipeClass;
-  const odValue = typeof ctx.od_mm === "number" ? ctx.od_mm : undefined;
-
-  if (pipeClass) {
-    for (const [groupName, result] of Object.entries(groups) as [Group, GroupEvalResult][]) {
-      const subtypeRules = SUBTYPE_RULES[groupName] ?? [];
-      if (!subtypeRules.length) continue;
-
-      let anySubtypeOk = false;
-      let missingInputs = false;
-      for (const rule of subtypeRules) {
-        const limit = rule.od_max_mm?.[pipeClass];
-        if (limit != null && odValue === undefined) {
-          missingInputs = true;
-          continue;
-        }
-        if (passClassOD(rule, pipeClass, odValue)) {
-          anySubtypeOk = true;
-          break;
-        }
-      }
-
-      if (!anySubtypeOk && !missingInputs) {
-        result.status = "forbidden";
-        pushOnce(result.reasons, "Tabla 12.2.9: ningún subtipo cumple clase/OD");
-      }
-    }
-  }
-
-  return groups;
+function findRow(id: string): LrShipRow | undefined {
+  return LR_SHIPS_SYSTEMS.find((row) => row.id === id);
 }
 
-function base(allowed: boolean, row: LRShipsSystem, group: Group): GroupEvalResult {
-  const result: GroupEvalResult = {
-    status: allowed ? "allowed" : "forbidden",
-    conditions: [],
-    reasons: [],
-    notesApplied: [],
-    clauses: [],
-    trace: [],
-  };
+function base(): Eval {
+  return { status: "allowed", conditions: [], reasons: [], notesApplied: [], clauses: [] };
+}
 
-  const baseMessage = `Tabla 12.2.8 (${row.label_es}): ${allowed ? "+" : "–"} para ${describeJointGroup(
-    group
-  )}; clasificación '${row.class_of_pipe_system}'.`;
-  result.trace.push(baseMessage);
-  if (!allowed) {
-    result.reasons.push(
-      `Tabla 12.2.8: la fila indica ‘-’ para ${describeJointGroup(group)}`
-    );
+function block(ev: Eval, reason: string) {
+  ev.status = "forbidden";
+  pushUnique(ev.reasons, reason);
+}
+
+function makeConditional(ev: Eval, condition: string) {
+  if (ev.status === "forbidden") return;
+  if (ev.status !== "conditional") {
+    ev.status = "conditional";
+  }
+  pushUnique(ev.conditions, condition);
+}
+
+function pushUnique<T>(arr: T[], value: T) {
+  if (!arr.includes(value)) arr.push(value);
+}
+
+function note(ev: Eval, n: number) {
+  if (!ev.notesApplied.includes(n)) {
+    ev.notesApplied.push(n);
+  }
+}
+
+function noteAll(out: Record<Group, Eval>, n: number) {
+  for (const group of Object.keys(out) as Group[]) {
+    note(out[group], n);
+  }
+}
+
+function forEachOpen(out: Record<Group, Eval>, fn: (ev: Eval) => void) {
+  for (const group of Object.keys(out) as Group[]) {
+    const ev = out[group];
+    if (ev.status !== "forbidden") {
+      fn(ev);
+    }
+  }
+}
+
+function forbidAll(reason: string): Record<Group, Eval> {
+  const result: Record<Group, Eval> = {
+    pipe_unions: base(),
+    compression_couplings: base(),
+    slip_on_joints: base(),
+  };
+  for (const group of Object.keys(result) as Group[]) {
+    block(result[group], reason);
   }
   return result;
 }
 
-function pushOnce<T>(arr: T[], value: T | null | undefined) {
-  if (value === undefined || value === null) return;
-  if (!arr.includes(value)) {
-    arr.push(value);
-  }
-}
-
-function forbidByClause(out: GroupEvalResult, msg: string, clause: ClauseRef) {
-  out.status = "forbidden";
-  pushOnce(out.reasons, msg);
-  if (!out.clauses) {
-    out.clauses = [];
-  }
-  out.clauses.push(clause);
-}
-
-function applyNote_LRShips(
-  ctx: LRShipsContext,
-  note: number,
-  group: Group,
-  out: GroupEvalResult
-) {
-  switch (note) {
-    case 2: {
-      if (group !== "slip_on_joints") break;
-      if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
-        out.status = "forbidden";
-        pushOnce(out.reasons, "Nota 2: Slip-on prohibidas en Cat. A / alojamientos");
-        pushOnce(out.notesApplied, note);
-        pushOnce(out.trace, `Nota 2: Slip-on prohibidas en ${ctx.space}.`);
-      } else if (
-        (ctx.space === "other_machinery" || ctx.space === "other_machinery_accessible") &&
-        ctx.location !== "visible_accessible"
-      ) {
-        out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-        pushOnce(
-          out.conditions,
-          "Ubicar en posición visible/accesible (Nota 2)"
-        );
-        pushOnce(out.notesApplied, note);
-        pushOnce(out.trace, "Nota 2: exigir ubicación visible/accesible en otras máquinas.");
-      }
-      break;
-    }
-    case 4: {
-      if (ctx.space === "machinery_cat_A") {
-        out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-        pushOnce(out.conditions, "Ensayo adicional en Cat. A (Nota 4)");
-        pushOnce(out.notesApplied, note);
-        pushOnce(out.trace, "Nota 4: Cat. A ⇒ ensayo de fuego específico.");
-      }
-      break;
-    }
-    case 3: {
-      if (ctx.space !== "open_deck") {
-        out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-        pushOnce(out.conditions, "Junta de tipo resistente al fuego (Nota 3)");
-        pushOnce(out.notesApplied, note);
-        pushOnce(out.trace, "Nota 3: exigir junta de tipo resistente al fuego.");
-      }
-      break;
-    }
-    case 5: {
-      if (ctx.space !== "open_deck") {
-        out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-        pushOnce(
-          out.conditions,
-          "Sólo sobre cubierta de francobordo (buques de pasaje)"
-        );
-        pushOnce(out.notesApplied, note);
-        pushOnce(out.trace, "Nota 5: restringir a cubierta de francobordo en buques de pasaje.");
-      }
-      break;
-    }
-    case 6: {
-      if (ctx.joint === "slip_on_slip_type" && ctx.space === "open_deck") {
-        const maxPressure = ctx.designPressure_bar ?? Number.POSITIVE_INFINITY;
-        if (maxPressure <= 10) {
-          out.status = out.status === "forbidden" ? "forbidden" : "conditional";
-          pushOnce(out.conditions, "Slip-type ≤10 bar en cubierta expuesta");
-          pushOnce(out.trace, "Nota 6: Slip-type permitido ≤10 bar en cubierta expuesta.");
-        } else {
-          out.status = "forbidden";
-          pushOnce(out.reasons, "Nota 6: Slip-type >10 bar prohibido");
-          pushOnce(out.trace, "Nota 6: Slip-type excede 10 bar ⇒ prohibido.");
-        }
-        pushOnce(out.notesApplied, note);
-      }
-      break;
-    }
-    case 7: {
-      pushOnce(out.trace, "Nota 7: revisar equivalencias de ensayo.");
-      break;
-    }
-    case 8: {
-      pushOnce(out.trace, "Nota 8: ver §2.12.10 para slip-on restringidas.");
-      break;
-    }
-  }
-}
-
-function applyGeneralClauses(ctx: LRShipsContext, group: Group, out: GroupEvalResult) {
-  if (out.status === "forbidden") {
-    return;
-  }
-
-  const isCargoOrTank = ctx.space === "cargo_hold" || ctx.space === "tank";
-  const isHardAccess = ctx.accessibility === "not_easy";
-
-  if (group === "slip_on_joints" && (isCargoOrTank || isHardAccess)) {
-    forbidByClause(
-      out,
-      "Slip-on no permitido en bodegas/tanques/espacios no fácilmente accesibles",
-      {
-        code: "SH-2.12.8",
-        title: "Slip-on no en bodegas/tanques/espacios no fácilmente accesibles",
-        section: "Pt 5, Ch 12, §2.12.8",
-      }
-    );
-  }
-
-  if (group === "slip_on_joints" && ctx.space === "tank" && ctx.mediumInPipeSameAsTank === false) {
-    forbidByClause(
-      out,
-      "Slip-on dentro de tanque: permitido sólo si el medio es el mismo",
-      {
-        code: "SH-2.12.8.b",
-        title: "Medio en tanque debe ser el mismo",
-        section: "Pt 5, Ch 12, §2.12.8",
-      }
-    );
-  }
-
-  const subtype = ctx.subtype ?? ctx.joint;
-  if ((subtype === "slip_on_slip_type" || subtype === "slip_type") && ctx.asMainMeans) {
-    forbidByClause(out, "Slip-type no como medio principal (sólo compensación axial)", {
-      code: "SH-2.12.9",
-      title: "Slip type: no como medio principal",
-      section: "Pt 5, Ch 12, §2.12.9",
-    });
-  }
-
-  if (ctx.directToShipSideBelowLimit || ctx.tankContainsFlammable) {
-    forbidByClause(
-      out,
-      "Prohibido en conexión directa al costado bajo el límite / tanques con fluidos inflamables",
-      {
-        code: "SH-2.12.5",
-        title: "Riesgo de incendio/inundación",
-        section: "Pt 5, Ch 12, §2.12.5",
-      }
-    );
-  }
-}
-
-function forbid(
-  ctx: LRShipsContext,
-  trace: string[],
-  message: string
-): LRShipsEvaluation {
-  return {
-    status: "forbidden",
-    conditions: [],
-    reasons: [message],
-    normRef: normReference,
-    reason: message,
-    systemId: ctx.systemId,
-    joint: ctx.joint,
-    pipeClass: ctx.pipeClass,
-    od_mm: ctx.od_mm,
-    designPressure_bar: ctx.designPressure_bar,
-    trace: [...trace],
-    observations: [message],
-    notesApplied: [],
-    clauses: [],
-  };
-}
-
-function groupOf(joint: Joint): LRShipsJointGroup | null {
-  if (joint === "pipe_unions" || joint === "compression_couplings" || joint === "slip_on_joints") {
-    return joint;
-  }
-  if (joint === "pipe_union_welded_brazed") return "pipe_unions";
-  if (
-    joint === "compression_swage" ||
-    joint === "compression_typical" ||
-    joint === "compression_bite" ||
-    joint === "compression_flared" ||
-    joint === "compression_press"
-  ) {
-    return "compression_couplings";
-  }
-  if (
-    joint === "slip_on_machine_grooved" ||
-    joint === "slip_on_grip" ||
-    joint === "slip_on_slip_type"
-  ) {
-    return "slip_on_joints";
-  }
-  return null;
-}
-
-function labelFire(value: LRShipsSystem["fire_test"]): string | null {
-  switch (value) {
+function labelFire(test: LrShipRow["fire_test"]): string | null {
+  switch (test) {
     case "30min_dry":
       return "30 min seco";
     case "30min_wet":
       return "30 min húmedo";
     case "8+22":
       return "8 min seco + 22 min húmedo";
-    case "not_required":
     default:
       return null;
   }
 }
 
-function describeJointGroup(group: LRShipsJointGroup) {
-  switch (group) {
-    case "pipe_unions":
-      return "pipe unions";
-    case "compression_couplings":
-      return "compression couplings";
-    case "slip_on_joints":
-      return "slip-on joints";
+function applyRowNotes(ctx: Ctx, row: LrShipRow, out: Record<Group, Eval>) {
+  if (!row.notes.length) return;
+
+  if (row.notes.includes(2)) {
+    const ev = out.slip_on_joints;
+    if (ev.status !== "forbidden") {
+      if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
+        block(ev, "Nota 2: Slip-on no aceptadas en Cat. A / alojamientos");
+      } else if (ctx.space === "other_machinery_accessible") {
+        makeConditional(ev, "Ubicar en posición visible/accesible (MSC/Circ.734)");
+      }
+      note(ev, 2);
+    }
+  }
+
+  if (row.notes.includes(3) && ctx.space !== "open_deck") {
+    forEachOpen(out, (ev) => makeConditional(ev, "Junta de tipo resistente al fuego"));
+    noteAll(out, 3);
+  }
+
+  if (row.notes.includes(4) && ctx.space === "machinery_cat_A") {
+    forEachOpen(out, (ev) => makeConditional(ev, "Ensayo adicional en Cat. A (Nota 4)"));
+    noteAll(out, 4);
   }
 }
 
-function collectRulesForJoint(joint: Joint): LRShipsSubtypeRule[] {
-  const group = groupOf(joint);
-  if (!group) {
-    return [];
+function applyClauses(ctx: Ctx, out: Record<Group, Eval>) {
+  const addClause = (
+    ev: Eval,
+    code: string,
+    section: string,
+    title: string,
+    reason: string,
+  ) => {
+    block(ev, reason);
+    ev.clauses.push({ code, section, title });
+  };
+
+  const slip = out.slip_on_joints;
+  if (slip.status !== "forbidden") {
+    const hardAccess =
+      ctx.space === "cargo_hold" || ctx.space === "tank" || ctx.accessibility === "not_easy";
+    if (hardAccess) {
+      addClause(
+        slip,
+        "SH-2.12.8",
+        "Pt 5, Ch 12, §2.12.8",
+        "Accesibilidad Slip-on",
+        "Slip-on no permitido en bodegas/tanques/espacios no fácilmente accesibles",
+      );
+    } else if (ctx.space === "tank" && ctx.mediumInPipeSameAsTank === false) {
+      addClause(
+        slip,
+        "SH-2.12.8.b",
+        "Pt 5, Ch 12, §2.12.8",
+        "Medio en tanque",
+        "Slip-on dentro de tanque: permitido sólo si el medio es el mismo",
+      );
+    }
   }
-  const rules = SUBTYPE_RULES[group] ?? [];
-  if (joint === group) {
-    return rules;
+
+  if (ctx.asMainMeans && out.slip_on_joints.status !== "forbidden") {
+    addClause(
+      out.slip_on_joints,
+      "SH-2.12.9",
+      "Pt 5, Ch 12, §2.12.9",
+      "Slip-type principal",
+      "Slip-type no puede ser medio principal",
+    );
   }
-  return rules.filter((rule) => rule.joint === joint);
+
+  const hazard = Boolean(ctx.directToShipSideBelowLimit || ctx.tankContainsFlammable);
+  if (hazard) {
+    forEachOpen(out, (ev) =>
+      addClause(
+        ev,
+        "SH-2.12.5",
+        "Pt 5, Ch 12, §2.12.5",
+        "Riesgo de incendio/inundación",
+        "Prohibido por riesgo de incendio/inundación",
+      ),
+    );
+  }
 }
 
-export function passClassOD(
-  rule: LRShipsSubtypeRule,
-  pipeClass: PipeClass,
-  odMM: number | undefined
-): boolean {
-  if (!rule.classes.includes(pipeClass)) {
-    return false;
+function applySubtypeLimits(ctx: Ctx, out: Record<Group, Eval>) {
+  const cls = ctx.pipeClass;
+  if (!cls) {
+    forEachOpen(out, (ev) => block(ev, "Tabla 12.2.9: requiere clase/OD"));
+    return;
   }
-  const limit = rule.od_max_mm?.[pipeClass];
-  if (limit == null) {
-    return true;
-  }
-  if (odMM === undefined) {
-    return false;
-  }
-  return odMM <= limit;
-}
 
-function formatRuleDetail(rule: LRShipsSubtypeRule, pipeClass: PipeClass): string {
-  const limit = rule.od_max_mm?.[pipeClass];
-  if (limit == null) {
-    return `Tabla 12.2.9: Clase ${pipeClass}`;
+  for (const group of Object.keys(out) as Group[]) {
+    const ev = out[group];
+    if (ev.status === "forbidden") continue;
+    const rules = SUBTYPE_RULES[group] ?? [];
+    const anyOk = rules.some((rule) => passClassOD(rule, cls, ctx.od_mm));
+    if (!anyOk) {
+      block(ev, "Tabla 12.2.9: ningún subtipo cumple clase/OD");
+    }
   }
-  return `Tabla 12.2.9: Clase ${pipeClass} con OD ≤ ${limit} mm`;
 }
-
-export default evaluateLRShips;

--- a/tests/lrShips.spec.ts
+++ b/tests/lrShips.spec.ts
@@ -1,24 +1,21 @@
 import { describe, expect, it } from "vitest";
-import evaluateLRShips, {
-  SUBTYPE_RULES,
-  evaluateGroups as evaluateLRShipsGroups,
-  passClassOD,
-} from "../dist/engine/lrShips.js";
+import { evaluateLRShips, SUBTYPE_RULES, passClassOD } from "../dist/engine/lrShips.js";
 
-describe("evaluateLRShips", () => {
-  it("marca condicional las slip-on en líneas de carga de hidrocarburos Cat. A Clase II", () => {
+describe("LR Ships mechanical joints", () => {
+  it("marca condicional los grupos por ensayo base en hidrocarburos", () => {
     const result = evaluateLRShips({
-      systemId: "hydrocarbon_loading_lines",
+      systemId: "hydrocarbon_loading_lines_fp_le_60",
       space: "machinery_cat_A",
       pipeClass: "II",
       od_mm: 60.3,
-      joint: "slip_on_joints",
       accessibility: "easy",
     });
 
-    expect(result.status).toBe("conditional");
-    expect(result.conditions).toContain("30 min seco");
-    expect(result.reasons).toHaveLength(0);
+    expect(result.pipe_unions.status).toBe("conditional");
+    expect(result.pipe_unions.conditions).toContain("30 min seco");
+    expect(result.compression_couplings.status).toBe("conditional");
+    expect(result.slip_on_joints.status).toBe("conditional");
+    expect(result.slip_on_joints.reasons.length).toBe(0);
   });
 
   it("valida Swage y Press según Tabla 12.2.9 para Clase II", () => {
@@ -29,28 +26,26 @@ describe("evaluateLRShips", () => {
     expect(pressRule && passClassOD(pressRule, "II", 60.3)).toBe(false);
   });
 
-  it("habilita los tres subtipos Slip-on en Clase II dentro de los límites", () => {
-    const mgRule = SUBTYPE_RULES.slip_on_joints.find((rule) => rule.id === "machine_grooved");
-    const gripRule = SUBTYPE_RULES.slip_on_joints.find((rule) => rule.id === "grip");
-    const slipRule = SUBTYPE_RULES.slip_on_joints.find((rule) => rule.id === "slip_type");
-
-    expect(mgRule && passClassOD(mgRule, "II", 60.3)).toBe(true);
-    expect(gripRule && passClassOD(gripRule, "II", 60.3)).toBe(true);
-    expect(slipRule && passClassOD(slipRule, "II", 60.3)).toBe(true);
+  it("habilita los subtipos Slip-on en Clase II dentro de los límites", () => {
+    const ids = ["machine_grooved", "grip", "slip_type"] as const;
+    for (const id of ids) {
+      const rule = SUBTYPE_RULES.slip_on_joints.find((item) => item.id === id);
+      expect(rule && passClassOD(rule, "II", 60.3)).toBe(true);
+    }
   });
 
   it("bloquea Slip-on en bodega por la cláusula 2.12.8", () => {
-    const groups = evaluateLRShipsGroups({
-      systemId: "hydrocarbon_loading_lines",
+    const result = evaluateLRShips({
+      systemId: "hydrocarbon_loading_lines_fp_le_60",
       space: "cargo_hold",
-      joint: "slip_on_joints",
       pipeClass: "III",
       od_mm: 73,
+      accessibility: "not_easy",
     });
 
-    const slipOn = groups.slip_on_joints;
+    const slipOn = result.slip_on_joints;
     expect(slipOn.status).toBe("forbidden");
-    expect(slipOn.clauses?.[0]?.section).toMatch(/§2\.12\.8/);
+    expect(slipOn.clauses[0]?.section).toMatch(/§2\.12\.8/);
   });
 
   it("rechaza Grip en Clase I por límite de Tabla 12.2.9", () => {


### PR DESCRIPTION
## Summary
- align the LR Ships 12.2.8 dataset with the new identifiers, joint flags, and version string
- rebuild the LR Ships evaluation engine to apply fire tests, notes, clauses, and subtype limits in order
- add a helper for the joints group card state and refresh the Vitest coverage for LR Ships rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deec69c9d48321b5869c972bea5448