### PR TITLE
Restore LR Ships joint evaluation compatibility

### DIFF
--- a/dist/engine/lrShips.js
+++ b/dist/engine/lrShips.js
@@ -22,32 +22,111 @@ export function passClassOD(rule, cls, od_mm) {
     const lim = rule.od_max_mm?.[cls];
     return lim ? (od_mm ?? Infinity) <= lim : true;
 }
-export function evaluateLRShips(ctx) {
-    const row = findRow(ctx.systemId);
-    const out = {
+const JOINT_GROUP_MAP = {
+    pipe_unions: "pipe_unions",
+    compression_couplings: "compression_couplings",
+    slip_on_joints: "slip_on_joints",
+    pipe_union_welded_brazed: "pipe_unions",
+    compression_swage: "compression_couplings",
+    compression_bite: "compression_couplings",
+    compression_typical: "compression_couplings",
+    compression_flared: "compression_couplings",
+    compression_press: "compression_couplings",
+    slip_on_machine_grooved: "slip_on_joints",
+    slip_on_grip: "slip_on_joints",
+    slip_on_slip_type: "slip_on_joints",
+};
+const JOINT_SUBTYPE_IDS = {
+    pipe_union_welded_brazed: "welded_brazed",
+    compression_swage: "swage",
+    compression_bite: "bite",
+    compression_typical: "typical",
+    compression_flared: "flared",
+    compression_press: "press",
+    slip_on_machine_grooved: "machine_grooved",
+    slip_on_grip: "grip",
+    slip_on_slip_type: "slip_type",
+};
+export function evaluateLRShips(ctx, dataset = LR_SHIPS_SYSTEMS) {
+    const { groups } = evaluateGroupsWithRow(ctx, dataset);
+    if (!ctx.joint) {
+        return cloneGroups(groups);
+    }
+    const group = JOINT_GROUP_MAP[ctx.joint];
+    if (!group) {
+        throw new Error(`Joint no reconocido: ${ctx.joint}`);
+    }
+    const base = cloneEval(groups[group]);
+    if (ctx.joint === group || base.status === "forbidden") {
+        return base;
+    }
+    const subtypeId = JOINT_SUBTYPE_IDS[ctx.joint];
+    if (!subtypeId) {
+        block(base, "Tabla 12.2.9: subtipo no reconocido");
+        return base;
+    }
+    const cls = ctx.pipeClass;
+    if (!cls) {
+        block(base, "Tabla 12.2.9: requiere clase/OD");
+        return base;
+    }
+    const rule = (SUBTYPE_RULES[group] ?? []).find((item) => item.id === subtypeId);
+    if (!rule) {
+        block(base, "Tabla 12.2.9: subtipo no reconocido");
+        return base;
+    }
+    if (!passClassOD(rule, cls, ctx.od_mm)) {
+        block(base, "Tabla 12.2.9: subtipo fuera de límite de clase/OD");
+    }
+    return base;
+}
+export function evaluateGroups(ctx, dataset = LR_SHIPS_SYSTEMS) {
+    const { groups } = evaluateGroupsWithRow(ctx, dataset);
+    return cloneGroups(groups);
+}
+function evaluateGroupsWithRow(ctx, dataset) {
+    const row = findRow(ctx.systemId, dataset);
+    const groups = {
         pipe_unions: base(),
         compression_couplings: base(),
         slip_on_joints: base(),
     };
     if (!row) {
-        return forbidAll("Fila 12.2.8 no encontrada");
+        forbidAll(groups, "Fila 12.2.8 no encontrada");
+        return { groups };
     }
-    for (const group of Object.keys(out)) {
+    for (const group of Object.keys(groups)) {
         if (!row.allowed_joints[group]) {
-            block(out[group], "Tabla 12.2.8: ‘−’ para este tipo de unión");
+            block(groups[group], "Tabla 12.2.8: ‘−’ para este tipo de unión");
         }
     }
     const fireLabel = labelFire(row.fire_test);
     if (fireLabel) {
-        forEachOpen(out, (ev) => makeConditional(ev, fireLabel));
+        forEachOpen(groups, (ev) => makeConditional(ev, fireLabel));
     }
-    applyRowNotes(ctx, row, out);
-    applyClauses(ctx, out);
-    applySubtypeLimits(ctx, out);
-    return out;
+    applyRowNotes(ctx, row, groups);
+    applyClauses(ctx, groups);
+    applySubtypeLimits(ctx, groups);
+    return { groups, row };
 }
-function findRow(id) {
-    return LR_SHIPS_SYSTEMS.find((row) => row.id === id);
+function cloneGroups(groups) {
+    return {
+        pipe_unions: cloneEval(groups.pipe_unions),
+        compression_couplings: cloneEval(groups.compression_couplings),
+        slip_on_joints: cloneEval(groups.slip_on_joints),
+    };
+}
+function cloneEval(ev) {
+    return {
+        status: ev.status,
+        conditions: [...ev.conditions],
+        reasons: [...ev.reasons],
+        notesApplied: [...ev.notesApplied],
+        clauses: ev.clauses.map((clause) => ({ ...clause })),
+    };
+}
+function findRow(id, dataset) {
+    return dataset.find((row) => row.id === id);
 }
 function base() {
     return { status: "allowed", conditions: [], reasons: [], notesApplied: [], clauses: [] };
@@ -86,16 +165,10 @@ function forEachOpen(out, fn) {
         }
     }
 }
-function forbidAll(reason) {
-    const result = {
-        pipe_unions: base(),
-        compression_couplings: base(),
-        slip_on_joints: base(),
-    };
-    for (const group of Object.keys(result)) {
-        block(result[group], reason);
+function forbidAll(out, reason) {
+    for (const group of Object.keys(out)) {
+        block(out[group], reason);
     }
-    return result;
 }
 function labelFire(test) {
     switch (test) {
@@ -173,3 +246,4 @@ function applySubtypeLimits(ctx, out) {
         }
     }
 }
+export default evaluateLRShips;


### PR DESCRIPTION
## Summary
- refactor the LR Ships evaluator to expose group calculations, support dataset overrides, and add joint-aware results with a default export for browser consumers
- rebuild the generated lrShips bundle so the UI can import evaluateLRShips/evaluateGroups after the TypeScript refactor
- extend the LR Ships regression suite with coverage for subtype-specific evaluations to guard against future regressions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68def1be4b088321a966d085c09c3c11