### PR TITLE
Fix LR ships dataset export for advisor

### DIFF
--- a/data/lr_ships_mech_joints.ts
+++ b/data/lr_ships_mech_joints.ts
@@ -125,3 +125,11 @@ export const LR_SHIPS_SYSTEMS: LrShipRow[] = [
 ];
 
 export const LR_SHIPS_DATA_VERSION = "2024-06-r2";
+
+export const LR_SHIPS_DATASET = {
+  standard: "LR_SHIPS",
+  version: LR_SHIPS_DATA_VERSION,
+  systems: LR_SHIPS_SYSTEMS,
+};
+
+export default LR_SHIPS_DATASET;

--- a/dist/data/lr_ships_mech_joints.js
+++ b/dist/data/lr_ships_mech_joints.js
@@ -85,3 +85,9 @@ export const LR_SHIPS_SYSTEMS = [
     },
 ];
 export const LR_SHIPS_DATA_VERSION = "2024-06-r2";
+export const LR_SHIPS_DATASET = {
+    standard: "LR_SHIPS",
+    version: LR_SHIPS_DATA_VERSION,
+    systems: LR_SHIPS_SYSTEMS,
+};
+export default LR_SHIPS_DATASET;


### PR DESCRIPTION
## Summary
- add a structured dataset export for the LR Ships mechanical joints data
- expose that dataset as the default export so the multi-rule advisor can import it unchanged

## Testing
- manual verification in browser


------
https://chatgpt.com/codex/tasks/task_e_68def957a3dc832188e65421980c98e4