### PR TITLE
Adjust LR Ships note 2 handling

### DIFF
--- a/dist/engine/lrShips.js
+++ b/dist/engine/lrShips.js
@@ -187,13 +187,21 @@ function applyRowNotes(ctx, row, out) {
         return;
     if (row.notes.includes(2)) {
         const ev = out.slip_on_joints;
-        if (ev.status !== "forbidden") {
-            if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
-                block(ev, "Nota 2: Slip-on no aceptadas en Cat. A / alojamientos");
+        let applied = false;
+        if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
+            if (ev.status !== "forbidden") {
+                ev.status = "forbidden";
             }
-            else if (ctx.space === "other_machinery_accessible") {
+            pushUnique(ev.reasons, "Slip-on no aceptadas en espacios de máquinas de categoría A ni alojamientos.");
+            applied = true;
+        }
+        else if (ctx.space === "other_machinery_accessible") {
+            if (ev.status !== "forbidden") {
                 makeConditional(ev, "Ubicar en posición visible/accesible (MSC/Circ.734)");
+                applied = true;
             }
+        }
+        if (applied) {
             note(ev, 2);
         }
     }

--- a/engine/lrShips.ts
+++ b/engine/lrShips.ts
@@ -270,12 +270,25 @@ function applyRowNotes(ctx: LRShipsContext, row: LrShipRow, out: GroupEvaluation
 
   if (row.notes.includes(2)) {
     const ev = out.slip_on_joints;
-    if (ev.status !== "forbidden") {
-      if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
-        block(ev, "Nota 2: Slip-on no aceptadas en Cat. A / alojamientos");
-      } else if (ctx.space === "other_machinery_accessible") {
-        makeConditional(ev, "Ubicar en posición visible/accesible (MSC/Circ.734)");
+    let applied = false;
+
+    if (ctx.space === "machinery_cat_A" || ctx.space === "accommodation") {
+      if (ev.status !== "forbidden") {
+        ev.status = "forbidden";
       }
+      pushUnique(
+        ev.reasons,
+        "Slip-on no aceptadas en espacios de máquinas de categoría A ni alojamientos.",
+      );
+      applied = true;
+    } else if (ctx.space === "other_machinery_accessible") {
+      if (ev.status !== "forbidden") {
+        makeConditional(ev, "Ubicar en posición visible/accesible (MSC/Circ.734)");
+        applied = true;
+      }
+    }
+
+    if (applied) {
       note(ev, 2);
     }
   }


### PR DESCRIPTION
## Summary
- update the LR Ships evaluator so note 2 only applies when its space-based restrictions are triggered
- replace the note-labelled blocking message with a neutral statement while keeping the slip-on prohibition in place
- regenerate the compiled lrShips engine output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68defef94da08321895d7b8ceb204f4f