### PR TITLE
Restrict LR naval slip-on joints to class I

### DIFF
--- a/data/lr_naval_ships_mech_joints.ts
+++ b/data/lr_naval_ships_mech_joints.ts
@@ -553,23 +553,19 @@ export const LR_NAVAL_DATASET = {
     {
       "joint": "slip_on_machine_grooved",
       "class": [
-        "I",
-        "II",
-        "III"
+        "I"
       ]
     },
     {
       "joint": "slip_on_grip",
       "class": [
-        "II",
-        "III"
+        "I"
       ]
     },
     {
       "joint": "slip_on_slip_type",
       "class": [
-        "II",
-        "III"
+        "I"
       ]
     }
   ],

--- a/dist/data/lr_naval_ships_mech_joints.js
+++ b/dist/data/lr_naval_ships_mech_joints.js
@@ -553,23 +553,19 @@ export const LR_NAVAL_DATASET = {
         {
             "joint": "slip_on_machine_grooved",
             "class": [
-                "I",
-                "II",
-                "III"
+                "I"
             ]
         },
         {
             "joint": "slip_on_grip",
             "class": [
-                "II",
-                "III"
+                "I"
             ]
         },
         {
             "joint": "slip_on_slip_type",
             "class": [
-                "II",
-                "III"
+                "I"
             ]
         }
     ],

--- a/tests/lrNavalShips.spec.ts
+++ b/tests/lrNavalShips.spec.ts
@@ -27,12 +27,12 @@ function evaluate(options: {
 }
 
 describe("evaluateLRNavalShips", () => {
-  it("marca condiciones para bilge Cat. A (Clase III) con slip-on", () => {
+  it("marca condiciones para bilge Cat. A (Clase I) con slip-on", () => {
     const result = evaluate({
       systemId: "bilge_lines",
       space: "machinery_cat_A",
       joint: "slip_on_machine_grooved",
-      pipeClass: "III",
+      pipeClass: "I",
       od_mm: 76,
     });
 
@@ -92,7 +92,7 @@ describe("evaluateLRNavalShips", () => {
       systemId: "steam",
       space: "open_deck",
       joint: "slip_on_machine_grooved",
-      pipeClass: "II",
+      pipeClass: "I",
       od_mm: 40,
       designPressure_bar: 8,
       shipType: "oil_tanker",
@@ -120,6 +120,19 @@ describe("evaluateLRNavalShips", () => {
     expect(result.reasons.some((msg) => msg.includes("Nota 5"))).toBe(true);
   });
 
+  it("bloquea slip-on Clase II por Tabla 1.5.4", () => {
+    const result = evaluate({
+      systemId: "aircraft_vehicle_fuel_lt60",
+      space: "other_machinery",
+      joint: "slip_on_machine_grooved",
+      pipeClass: "II",
+      od_mm: 50,
+    });
+
+    expect(result.status).toBe("forbidden");
+    expect(result.reason).toContain("Tabla 1.5.4");
+  });
+
   it("mantiene slip-on machine grooved disponible en bilge Cat. A al agrupar", () => {
     const group = evaluateLRNavalGroups({
       systemId: "bilge_lines",
@@ -133,7 +146,7 @@ describe("evaluateLRNavalShips", () => {
       systemId: "bilge_lines",
       space: "machinery_cat_A",
       joint: "slip_on_machine_grooved",
-      pipeClass: "III",
+      pipeClass: "I",
       od_mm: 76,
     });
 
@@ -159,7 +172,7 @@ describe("evaluateLRNavalShips", () => {
       systemId: "bilge_lines",
       space: "machinery_cat_A",
       joint: "slip_on_joints",
-      pipeClass: "III",
+      pipeClass: "I",
       od_mm: 114.3,
     });
 


### PR DESCRIPTION
## Summary
- align LR Naval slip-on joint class limits with Table 12.2.9 by restricting all slip-on variants to Class I
- update naval evaluation tests to reflect the new class limits and cover the Class II rejection scenario

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df01b77d9c8321af4036f2564a56c8