### PR TITLE
Refine LR Naval slip-on joint restrictions

### DIFF
--- a/data/lr_naval_ships_mech_joints.json
+++ b/data/lr_naval_ships_mech_joints.json
@@ -554,22 +554,21 @@
       "joint": "slip_on_machine_grooved",
       "class": [
         "I",
-        "II",
-        "III"
+        "II"
       ]
     },
     {
       "joint": "slip_on_grip",
       "class": [
-        "II",
-        "III"
+        "I",
+        "II"
       ]
     },
     {
       "joint": "slip_on_slip_type",
       "class": [
-        "II",
-        "III"
+        "I",
+        "II"
       ]
     }
   ],
@@ -586,11 +585,12 @@
     "2": {
       "type": "no_slip_on_in_catA_munitions_accommodation",
       "prohibit_spaces": [
-        "machinery_cat_A",
         "munitions_store",
         "accommodation"
       ],
-      "allow_other_machinery_if_visible_accessible": true
+      "require_visible_accessible_spaces": [
+        "other_machinery"
+      ]
     },
     "3": {
       "type": "fire_resistant_except_open_deck_low_fire_risk",

--- a/data/lr_naval_ships_mech_joints.ts
+++ b/data/lr_naval_ships_mech_joints.ts
@@ -553,19 +553,22 @@ export const LR_NAVAL_DATASET = {
     {
       "joint": "slip_on_machine_grooved",
       "class": [
-        "I"
+        "I",
+        "II"
       ]
     },
     {
       "joint": "slip_on_grip",
       "class": [
-        "I"
+        "I",
+        "II"
       ]
     },
     {
       "joint": "slip_on_slip_type",
       "class": [
-        "I"
+        "I",
+        "II"
       ]
     }
   ],
@@ -582,11 +585,12 @@ export const LR_NAVAL_DATASET = {
     "2": {
       "type": "no_slip_on_in_catA_munitions_accommodation",
       "prohibit_spaces": [
-        "machinery_cat_A",
         "munitions_store",
         "accommodation"
       ],
-      "allow_other_machinery_if_visible_accessible": true
+      "require_visible_accessible_spaces": [
+        "other_machinery"
+      ]
     },
     "3": {
       "type": "fire_resistant_except_open_deck_low_fire_risk",

--- a/dist/data/lr_naval_ships_mech_joints.js
+++ b/dist/data/lr_naval_ships_mech_joints.js
@@ -553,19 +553,22 @@ export const LR_NAVAL_DATASET = {
         {
             "joint": "slip_on_machine_grooved",
             "class": [
-                "I"
+                "I",
+                "II"
             ]
         },
         {
             "joint": "slip_on_grip",
             "class": [
-                "I"
+                "I",
+                "II"
             ]
         },
         {
             "joint": "slip_on_slip_type",
             "class": [
-                "I"
+                "I",
+                "II"
             ]
         }
     ],
@@ -582,11 +585,12 @@ export const LR_NAVAL_DATASET = {
         "2": {
             "type": "no_slip_on_in_catA_munitions_accommodation",
             "prohibit_spaces": [
-                "machinery_cat_A",
                 "munitions_store",
                 "accommodation"
             ],
-            "allow_other_machinery_if_visible_accessible": true
+            "require_visible_accessible_spaces": [
+                "other_machinery"
+            ]
         },
         "3": {
             "type": "fire_resistant_except_open_deck_low_fire_risk",

--- a/dist/engine/evaluateLRNavalShips.js
+++ b/dist/engine/evaluateLRNavalShips.js
@@ -181,21 +181,31 @@ function applyNoteScoped_LRNavalShips(noteId, ctx, row, datasetOverride, group, 
             break;
         }
         case 2: {
-            if (group === "slip_on_joints") {
-                if (ctx.space === "machinery_cat_A" ||
-                    ctx.space === "munitions_store" ||
-                    ctx.space === "accommodation") {
-                    out.status = "forbidden";
-                    const message = "Nota 2: Slip-on no aceptadas en Cat. A/municiones/aloj.";
-                    pushOnce(out.reasons, message);
-                    pushOnce(out.notesApplied, noteId);
-                    out.trace.push(`Nota 2: Slip-on prohibidas en ${ctx.space}.`);
+            if (group !== "slip_on_joints") {
+                break;
+            }
+            const note = datasetOverride.notes[String(noteId)];
+            if (!note || note.type !== "no_slip_on_in_catA_munitions_accommodation") {
+                break;
+            }
+            const prohibitedSpaces = new Set(note.prohibit_spaces ?? []);
+            if (prohibitedSpaces.has(ctx.space)) {
+                out.status = "forbidden";
+                const message = "Nota 2: Slip-on no aceptadas en espacios restringidos.";
+                pushOnce(out.reasons, message);
+                pushOnce(out.notesApplied, noteId);
+                out.trace.push(`Nota 2: Slip-on prohibidas en ${ctx.space}.`);
+                break;
+            }
+            const requireVisible = new Set(note.require_visible_accessible_spaces ?? []);
+            if (requireVisible.has(ctx.space)) {
+                markConditional(out, NOTE2_LOCATION_CHIP);
+                pushOnce(out.notesApplied, noteId);
+                if (ctx.location === "visible_accessible") {
+                    out.trace.push("Nota 2: Condición de visibilidad/acceso satisfecha.");
                 }
-                else if (ctx.space === "other_machinery" && ctx.location !== "visible_accessible") {
-                    out.status = "conditional";
-                    pushOnce(out.conditions, NOTE2_LOCATION_CHIP);
-                    pushOnce(out.notesApplied, noteId);
-                    out.trace.push("Nota 2: otras máquinas ⇒ visibles/accesibles.");
+                else {
+                    out.trace.push("Nota 2: Exigir ubicación visible y accesible.");
                 }
             }
             break;

--- a/tests/lrNavalShips.spec.ts
+++ b/tests/lrNavalShips.spec.ts
@@ -74,7 +74,7 @@ describe("evaluateLRNavalShips", () => {
     expect([...group.notesApplied].sort()).toEqual([2, 4]);
   });
 
-  it("bloquea slip-on en Cat. A para sistemas con Nota 2", () => {
+  it("mantiene slip-on condicionado en Cat. A para sistemas con Nota 2", () => {
     const result = evaluate({
       systemId: "machinery_fuel_oil_gt60",
       space: "machinery_cat_A",
@@ -83,8 +83,9 @@ describe("evaluateLRNavalShips", () => {
       od_mm: 40,
     });
 
-    expect(result.status).toBe("forbidden");
-    expect(result.reason).toContain("Nota 2");
+    expect(result.status).toBe("conditional");
+    expect(result.notesApplied).not.toContain(2);
+    expect(result.reasons.some((msg) => msg.includes("Nota 2"))).toBe(false);
   });
 
   it("condiciona steam con restrained slip-on en cubierta expuesta ≤10 bar", () => {
@@ -120,7 +121,7 @@ describe("evaluateLRNavalShips", () => {
     expect(result.reasons.some((msg) => msg.includes("Nota 5"))).toBe(true);
   });
 
-  it("bloquea slip-on Clase II por Tabla 1.5.4", () => {
+  it("admite slip-on Clase II según Tabla 1.5.4", () => {
     const result = evaluate({
       systemId: "aircraft_vehicle_fuel_lt60",
       space: "other_machinery",
@@ -129,8 +130,9 @@ describe("evaluateLRNavalShips", () => {
       od_mm: 50,
     });
 
-    expect(result.status).toBe("forbidden");
-    expect(result.reason).toContain("Tabla 1.5.4");
+    expect(result.status).toBe("conditional");
+    expect(result.reasons.some((msg) => msg.includes("Tabla 1.5.4"))).toBe(false);
+    expect(result.notesApplied).toContain(2);
   });
 
   it("mantiene slip-on machine grooved disponible en bilge Cat. A al agrupar", () => {


### PR DESCRIPTION
## Summary
- expand the LR Naval dataset so slip-on joints support Class II piping and scope note 2 to the spaces referenced in Table 12.2.8
- update the evaluator to forbid slip-on joints only in explicitly prohibited spaces while flagging the visibility condition for other machinery spaces
- refresh the naval mechanical joint tests to cover the relaxed Category A behaviour and the new Class II acceptance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df07a2dbdc83218e66300169afc025