### PR TITLE
Add joint image viewer modal

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6,7 +6,16 @@ label { margin-right:12px; }
 .card.conditional { border-color:#f59e0b; }
 .card.forbidden { border-color:#ef4444; opacity:.8; }
 .tag { display:inline-block; margin:4px 6px 0 0; padding:2px 8px; border-radius:999px; background:#27304a; font-size:12px; }
-.subtype { display:flex; align-items:center; gap:8px; }
+.subtype { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.subtype-label { display:flex; align-items:center; gap:8px; }
 .subtype .dot { width:10px; height:10px; border-radius:50%; background:#ef4444; }
 .subtype.valid .dot { background:#10b981; }
+.subtype-invalid { font-size:12px; opacity:.75; }
+.ver-btn { background:#1d253d; color:#93c5fd; border:1px solid #1e3a8a; border-radius:999px; padding:4px 12px; font-size:12px; letter-spacing:.05em; text-transform:uppercase; cursor:pointer; transition:background .2s ease, color .2s ease; }
+.ver-btn:hover { background:#2563eb; color:#0f172a; }
 h3 { margin:0 0 8px; }
+.img-modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.8);z-index:9999}
+.img-modal.hidden{display:none}
+.img-modal img{max-width:min(92vw,1200px);max-height:88vh;border-radius:12px;box-shadow:0 10px 40px rgba(0,0,0,.6)}
+.img-modal .close{position:absolute;top:16px;right:16px;font-size:28px;background:#111;color:#fff;border:0;border-radius:8px;padding:6px 10px;cursor:pointer}
+#imgModalCaption{position:absolute;left:0;right:0;bottom:20px;color:#fff;text-align:center;opacity:.9}

--- a/assets/js/joint-images.js
+++ b/assets/js/joint-images.js
@@ -1,0 +1,22 @@
+// Mapea el ID del subtipo a su archivo en /assets/joints
+export const JOINT_IMAGE_MAP = {
+  // Pipe unions
+  welded_brazed: "pipe_welded_brazed.jpg",
+
+  // Compression couplings
+  swage: "compression_swage.jpg",
+  press: "compression_press.jpg",
+  typical: "compression_typical.jpg",
+  bite: "compression_bite.jpg",
+  flared: "compression_flared.jpg",
+
+  // Slip-on joints
+  machine_grooved: "slip_machine_grooved.jpg",
+  grip: "slip_grip.jpg",
+  slip_type: "slip_slip.jpg",
+};
+
+export function getJointImageSrc(subtypeId) {
+  const file = JOINT_IMAGE_MAP[subtypeId] ?? "not-found.jpg";
+  return `assets/joints/${file}`;
+}

--- a/assets/js/joint-viewer.js
+++ b/assets/js/joint-viewer.js
@@ -1,0 +1,43 @@
+import { getJointImageSrc } from "./joint-images.js";
+
+function openImageModal(src, caption) {
+  const modal = document.getElementById("imgModal");
+  const img = document.getElementById("imgModalPic");
+  const cap = document.getElementById("imgModalCaption");
+  img.src = src;
+  img.alt = caption;
+  cap.textContent = caption || "";
+  modal.classList.remove("hidden");
+}
+
+function closeImageModal() {
+  const modal = document.getElementById("imgModal");
+  const img = document.getElementById("imgModalPic");
+  img.src = "";
+  document.getElementById("imgModalCaption").textContent = "";
+  modal.classList.add("hidden");
+}
+
+(function wireModal() {
+  const modal = document.getElementById("imgModal");
+  if (!modal) return;
+  modal.addEventListener("click", (e) => {
+    if (e.target.id === "imgModal" || e.target.classList.contains("close")) {
+      closeImageModal();
+    }
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeImageModal();
+  });
+})();
+
+// Llama a esto DESPUÉS de renderizar las tarjetas (cada evaluación)
+export function wireViewButtons(root = document) {
+  root.querySelectorAll('[data-action="view-joint"]').forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const id = btn.dataset.subtypeId;
+      const name = btn.dataset.subtypeName || btn.textContent.trim();
+      openImageModal(getJointImageSrc(id), name);
+    });
+  });
+}

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -1,3 +1,5 @@
+import { wireViewButtons } from "./joint-viewer.js";
+
 export function renderUI({ row, result }) {
   const cards = document.querySelector("#cards");
   cards.innerHTML = "";
@@ -21,13 +23,25 @@ export function renderUI({ row, result }) {
       ${noteList.length ? `<div style="margin-top:8px">Notas de referencia: ${noteList.map(n=>`<span class="tag note">Nota ${n}</span>`).join(" ")}</div>` : ""}
       <div style="margin-top:8px">Subtipos:</div>
       <div>${ev.subtypes.map(s=>`
-        <div class="subtype ${s.valid?'valid':''}">
-          <span class="dot"></span><span>${s.name}</span> ${s.valid?'':'(no válido por clase/OD)'}
+        <div class="subtype ${s.valid ? 'valid' : ''}">
+          <div class="subtype-label">
+            <span class="dot"></span>
+            <span>${s.name}</span>
+            ${s.valid ? '' : '<span class="subtype-invalid">(no válido por clase/OD)</span>'}
+          </div>
+          <button class="ver-btn" type="button"
+                  data-action="view-joint"
+                  data-subtype-id="${s.id}"
+                  data-subtype-name="${s.name}">
+            VER
+          </button>
         </div>`).join("")}
       </div>
     `;
     cards.appendChild(el);
   });
+
+  wireViewButtons(cards);
 
   const notes = document.querySelector("#notes");
   if (row) {

--- a/index.html
+++ b/index.html
@@ -50,6 +50,13 @@
 
   <section id="notes"></section>
 
+  <!-- Visor de imágenes de juntas -->
+  <div id="imgModal" class="img-modal hidden" role="dialog" aria-modal="true" aria-label="Vista de imagen">
+    <button class="close" type="button" aria-label="Cerrar">×</button>
+    <img id="imgModalPic" alt="">
+    <div id="imgModalCaption"></div>
+  </div>
+
   <script type="module" src="assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add image mapping and viewer scripts to resolve joint image sources and modal behavior
- style subtype cards with dedicated view buttons and wire them to open the modal
- embed the modal container in the index page and extend styles for modal presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df298a99a88321a055d99157c5581e