### PR TITLE
Fix modal behavior and subtype markup

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,3 +1,5 @@
+.hidden { display: none !important; }
+
 body { font-family: system-ui, sans-serif; background:#0e1320; color:#e9eef8; margin:24px; }
 label { margin-right:12px; }
 .grid { display:grid; grid-template-columns: repeat(3, 1fr); gap:16px; margin-top:16px; }
@@ -19,3 +21,5 @@ h3 { margin:0 0 8px; }
 .img-modal img{max-width:min(92vw,1200px);max-height:88vh;border-radius:12px;box-shadow:0 10px 40px rgba(0,0,0,.6)}
 .img-modal .close{position:absolute;top:16px;right:16px;font-size:28px;background:#111;color:#fff;border:0;border-radius:8px;padding:6px 10px;cursor:pointer}
 #imgModalCaption{position:absolute;left:0;right:0;bottom:20px;color:#fff;text-align:center;opacity:.9}
+
+body.modal-open { overflow: hidden; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,3 +1,5 @@
+import "./joint-images.js";
+import "./joint-viewer.js";
 import { LR_SHIPS_SYSTEMS } from "./data-lr-ships.js";
 import { LR_NAVAL_SYSTEMS } from "./data-lr-naval.js";
 import { evaluateLRShips } from "./engine-lr-ships.js";

--- a/assets/js/joint-viewer.js
+++ b/assets/js/joint-viewer.js
@@ -1,13 +1,18 @@
 import { getJointImageSrc } from "./joint-images.js";
 
+let lastFocusedElement = null;
+
 function openImageModal(src, caption) {
   const modal = document.getElementById("imgModal");
   const img = document.getElementById("imgModalPic");
   const cap = document.getElementById("imgModalCaption");
+  lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   img.src = src;
   img.alt = caption;
   cap.textContent = caption || "";
   modal.classList.remove("hidden");
+  document.body?.classList.add("modal-open");
+  modal.querySelector(".close")?.focus();
 }
 
 function closeImageModal() {
@@ -16,6 +21,11 @@ function closeImageModal() {
   img.src = "";
   document.getElementById("imgModalCaption").textContent = "";
   modal.classList.add("hidden");
+  document.body?.classList.remove("modal-open");
+  if (lastFocusedElement) {
+    lastFocusedElement.focus();
+    lastFocusedElement = null;
+  }
 }
 
 (function wireModal() {


### PR DESCRIPTION
## Summary
- ensure the shared hidden class reliably removes modal elements from the layout and prevent body scrolling while open
- import the viewer modules from the app entry point so they load before the UI renders
- improve the modal focus handling to return focus to the triggering control after closing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df308b797083218c815069a5fbcffe