### PR TITLE
Add modal integration for joint evaluator

### DIFF
--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -71,6 +71,16 @@
     height: auto;
     border-radius: 14px;
   }
+  .header-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 20px;
+  }
+  .header-cta {
+    font-size: 15px;
+    padding: 12px 20px;
+  }
   h1 {
     font-size: clamp(26px, 4vw, 38px);
     margin: 0 0 12px;
@@ -337,6 +347,39 @@
     line-height: 1.6;
     text-align: center;
   }
+  /* Modal genérico para el evaluador LR de juntas */
+  .lrj-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.8);
+    z-index: 9999;
+  }
+  .lrj-modal.open { display: flex; }
+
+  .lrj-modal iframe {
+    width: min(1200px, 95vw);
+    height: 90vh;
+    border: 0;
+    border-radius: 12px;
+    background: #0e1320;
+  }
+
+  .lrj-close {
+    position: absolute;
+    top: 14px;
+    right: 16px;
+    font-size: 28px;
+    line-height: 1;
+    background: #111;
+    color: #fff;
+    border: 0;
+    border-radius: 8px;
+    padding: 6px 10px;
+    cursor: pointer;
+  }
   @media (max-width: 940px) {
     .grid { grid-template-columns: 1fr; }
     .card.result { position: static; }
@@ -353,6 +396,11 @@
         Basado en norma GL para compatibilidad de rutas de tuberías; para agua potable se
         considera IMO. Criterios complementados con la experiencia del astillero COTECMAR.
       </p>
+      <div class="header-actions">
+        <button id="btnJuntasLR" type="button" class="btn-primary header-cta">
+          Evaluador LR — Juntas mecánicas
+        </button>
+      </div>
     </div>
     <div class="header-brand">
       <img src="assets/joints/cotec.jpg" alt="Cotecmar" />
@@ -437,6 +485,17 @@
         <tbody></tbody>
       </table>
     </div>
+  </div>
+
+  <!-- Modal que contiene el evaluador de juntas/uniones -->
+  <div id="juntasModal" class="lrj-modal" aria-hidden="true">
+    <button class="lrj-close" type="button" aria-label="Cerrar">×</button>
+    <iframe id="juntasFrame"
+            src="Pasos-Uniones-Guia/index.html"
+            title="Evaluador LR — Juntas mecánicas"
+            loading="lazy"
+            referrerpolicy="no-referrer"
+            allow="fullscreen"></iframe>
   </div>
 
   <footer>
@@ -1403,6 +1462,36 @@ window.addEventListener('DOMContentLoaded',()=>{
   resetNotes();
   cleanseLegacyTableRefs();
 });
+</script>
+<script>
+  (function () {
+    const openBtn = document.getElementById('btnJuntasLR');
+    const modal   = document.getElementById('juntasModal');
+    const close   = modal.querySelector('.lrj-close');
+    const frame   = document.getElementById('juntasFrame');
+
+    function openModal() {
+      modal.classList.add('open');
+      modal.setAttribute('aria-hidden', 'false');
+    }
+
+    function closeModal() {
+      modal.classList.remove('open');
+      modal.setAttribute('aria-hidden', 'true');
+      // frame.src = frame.src;
+    }
+
+    openBtn.addEventListener('click', openModal);
+    close.addEventListener('click', closeModal);
+
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) closeModal();
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && modal.classList.contains('open')) closeModal();
+    });
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a CTA in the compatibilidad tool to open the LR joint evaluator
- include global modal markup and styling to host the iframe
- wire a lightweight script to open and close the modal from the CTA

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3e98e9d8832180b0f01417b81507