### PR TITLE
Update legacy viewer button to open compatibilidad

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       <div class="card">
         <h2>Visor ligero (legacy)</h2>
         <p>Versión sin dependencias adicionales (para pruebas o dispositivos lentos).</p>
-        <a class="btn" href="asesor-grip-type-nobabel.html">Abrir visor ligero</a>
+        <a class="btn" href="compatibilidad.html" target="_top" rel="noopener">Abrir visor ligero</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- point the legacy viewer button to compatibilidad.html
- ensure the link opens in the top window outside the iframe

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4a8dc0f4832188d559d8eb89a3c8