### PR TITLE
Replace module script with consolidated bootstrapping

### DIFF
--- a/asesor-grip-type-multi.html
+++ b/asesor-grip-type-multi.html
@@ -331,50 +331,52 @@
   <div id="root" class="min-h-[40vh]"></div>
 
     <script type="module">
-    const showError = (err) => {
-      const el = document.getElementById('root');
-      if (el) {
+      const showError = (err) => {
+        const el = document.getElementById('root');
         el.innerHTML = `<pre style="white-space:pre-wrap">${(err && (err.stack || err.message)) || err}</pre>`;
+      };
+
+      try {
+        // 1) React + ReactDOM (client)
+        const React = await import('https://esm.sh/react@18.2.0');
+        const ReactDOM = await import('https://esm.sh/react-dom@18.2.0/client');
+
+        // 2) HTM → bind a React.createElement  (¡clave!)
+        const htmMod = await import('https://unpkg.com/htm@3.1.1/dist/htm.module.js');
+        const html = htmMod.default.bind(React.createElement);
+
+        // 3) Módulos locales (rutas exactas)
+        const { RULESETS } = await import('./rulesets/index.js');
+        const { RegulationEngines } = await import('./engines.js');
+        const { I18N } = await import('./i18n/index.js');
+        // engines (si exponen efectos/registran evaluadores)
+        await import('./dist/engine/lrShips.js');
+        await import('./dist/engine/evaluateLRNavalShips.js');
+        // datasets
+        const ships = (await import('./dist/data/lr_ships_mech_joints.js')).default;
+        const naval = (await import('./dist/data/lr_naval_ships_mech_joints.js')).default;
+
+        // 4) Tu UI modularizada
+        const { default: App } = await import('./app-multi.js');
+
+        // 5) Montaje (un solo render)
+        const rootEl = document.getElementById('root');
+        const createRoot = (ReactDOM.createRoot || ReactDOM.default?.createRoot);
+        if (!createRoot) throw new Error('ReactDOM.createRoot no disponible');
+        createRoot(rootEl).render(
+          html`<${App}
+            html=${html}
+            RULESETS=${RULESETS}
+            RegulationEngines=${RegulationEngines}
+            I18N=${I18N}
+            ships=${ships}
+            naval=${naval}
+          />`
+        );
+      } catch (err) {
+        showError(err);
+        console.error(err);
       }
-    };
-
-    try {
-      // React + ReactDOM (client)
-      const React = await import('https://esm.sh/react@18.2.0');
-      const ReactDOM = await import('https://esm.sh/react-dom@18.2.0/client');
-
-      // HTM: IMPORTA Y *BIND* A React.createElement  ⬅️⬅️⬅️  ESTE ES EL FIX
-      const htm = (await import('https://unpkg.com/htm@3.1.1/dist/htm.module.js')).default;
-      const html = htm.bind(React.createElement);
-
-      // Módulos locales (deben existir en esas rutas)
-      const { RULESETS } = await import('./rulesets/index.js');
-      const { RegulationEngines } = await import('./engines.js');
-      const { I18N } = await import('./i18n/index.js');
-      await import('./dist/engine/lrShips.js');
-      await import('./dist/engine/evaluateLRNavalShips.js');
-      const ships = (await import('./dist/data/lr_ships_mech_joints.js')).default;
-      const naval = (await import('./dist/data/lr_naval_ships_mech_joints.js')).default;
-
-      // Tu UI modularizada
-      const { default: App } = await import('./app-multi.js');
-
-      const rootEl = document.getElementById('root');
-      const createRoot = (ReactDOM.createRoot || ReactDOM.default?.createRoot);
-      if (!createRoot) throw new Error('ReactDOM.createRoot no disponible');
-      createRoot(rootEl).render(
-        html`<${App}
-          RULESETS=${RULESETS}
-          RegulationEngines=${RegulationEngines}
-          I18N=${I18N}
-          ships=${ships}
-          naval=${naval}
-        />`
-      );
-    } catch (err) {
-      showError(err);
-      console.error(err);
-    }
-  </script>
-</body>
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the inline module loader in asesor-grip-type-multi.html with a single consolidated bootstrap script
- ensure the HTM helper is bound once and pass it into the React app along with the required datasets and engines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc6f38e3883218bea1237e6b5c6e2