### PR TITLE
Update multi advisor bootstrap script

### DIFF
--- a/asesor-grip-type-multi.html
+++ b/asesor-grip-type-multi.html
@@ -330,53 +330,58 @@
   </div>
   <div id="root" class="min-h-[40vh]"></div>
 
-    <script type="module">
-      const showError = (err) => {
-        const el = document.getElementById('root');
-        el.innerHTML = `<pre style="white-space:pre-wrap">${(err && (err.stack || err.message)) || err}</pre>`;
-      };
+  <script type="module">
+    const rootEl = document.getElementById('root');
 
-      try {
-        // 1) React + ReactDOM (client)
-        const React = await import('https://esm.sh/react@18.2.0');
-        const ReactDOM = await import('https://esm.sh/react-dom@18.2.0/client');
+    const showError = (err) => {
+      if (!rootEl) return;
+      rootEl.innerHTML = `<pre style="white-space:pre-wrap">${(err && (err.stack || err.message)) || err}</pre>`;
+    };
 
-        // 2) HTM → bind a React.createElement  (¡clave!)
-        const htmMod = await import('https://unpkg.com/htm@3.1.1/dist/htm.module.js');
-        const html = htmMod.default.bind(React.createElement);
+    try {
+      // 1) React + ReactDOM (client)
+      const React = await import('https://esm.sh/react@18.2.0');
+      const ReactDOM = await import('https://esm.sh/react-dom@18.2.0/client');
 
-        // 3) Módulos locales (rutas exactas)
-        const { RULESETS } = await import('./rulesets/index.js');
-        const { RegulationEngines } = await import('./engines.js');
-        const { I18N } = await import('./i18n/index.js');
-        // engines (si exponen efectos/registran evaluadores)
-        await import('./dist/engine/lrShips.js');
-        await import('./dist/engine/evaluateLRNavalShips.js');
-        // datasets
-        const ships = (await import('./dist/data/lr_ships_mech_joints.js')).default;
-        const naval = (await import('./dist/data/lr_naval_ships_mech_joints.js')).default;
+      // 2) HTM → bind a React.createElement (¡clave!)
+      const htmMod = await import('https://unpkg.com/htm@3.1.1/dist/htm.module.js');
+      const html = htmMod.default.bind(React.createElement);
 
-        // 4) Tu UI modularizada
-        const { default: App } = await import('./app-multi.js');
+      // 3) Módulos locales (rutas exactas). Evita duplicados.
+      const [{ RULESETS }, { RegulationEngines }, { I18N }, shipsMod, navalMod, { default: App }] =
+        await Promise.all([
+          import('./rulesets/index.js'),
+          import('./engines.js'),
+          import('./i18n/index.js'),
+          import('./dist/data/lr_ships_mech_joints.js'),
+          import('./dist/data/lr_naval_ships_mech_joints.js'),
+          import('./app-multi.js'),
+        ]);
 
-        // 5) Montaje (un solo render)
-        const rootEl = document.getElementById('root');
-        const createRoot = (ReactDOM.createRoot || ReactDOM.default?.createRoot);
-        if (!createRoot) throw new Error('ReactDOM.createRoot no disponible');
-        createRoot(rootEl).render(
-          html`<${App}
-            html=${html}
-            RULESETS=${RULESETS}
-            RegulationEngines=${RegulationEngines}
-            I18N=${I18N}
-            ships=${ships}
-            naval=${naval}
-          />`
-        );
-      } catch (err) {
-        showError(err);
-        console.error(err);
-      }
-    </script>
+      // 4) Engines (si registran evaluadores o efectos internos)
+      await Promise.all([
+        import('./dist/engine/lrShips.js'),
+        import('./dist/engine/evaluateLRNavalShips.js'),
+      ]);
+
+      // 5) Montaje (un único render)
+      const createRoot = (ReactDOM.createRoot || ReactDOM.default?.createRoot);
+      if (!createRoot) throw new Error('ReactDOM.createRoot no disponible');
+
+      createRoot(rootEl).render(
+        html`<${App}
+          html=${html}
+          RULESETS=${RULESETS}
+          RegulationEngines=${RegulationEngines}
+          I18N=${I18N}
+          ships=${shipsMod.default}
+          naval=${navalMod.default}
+        />`
+      );
+    } catch (err) {
+      showError(err);
+      console.error(err);
+    }
+  </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the module bootstrap in asesor-grip-type-multi.html with the provided unified loader
- keep the base href in the head so local imports resolve correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfc913384c83219b175076e6f74db1