### PR TITLE
Update multi grip type bootstrap

### DIFF
--- a/asesor-grip-type-multi.html
+++ b/asesor-grip-type-multi.html
@@ -347,33 +347,43 @@
       const htmMod = await import('https://unpkg.com/htm@3.1.1/dist/htm.module.js');
       const html = htmMod.default.bind(React.createElement);
 
-      // 3) Módulos locales (rutas exactas). Evita duplicados.
-      const [{ RULESETS }, { RegulationEngines }, { I18N }, shipsMod, navalMod, { default: App }] =
-        await Promise.all([
-          import('./rulesets/index.js'),
-          import('./engines.js'),
-          import('./i18n/index.js'),
-          import('./dist/data/lr_ships_mech_joints.js'),
-          import('./dist/data/lr_naval_ships_mech_joints.js'),
-          import('./app-multi.js'),
-        ]);
-
-      // 4) Engines (si registran evaluadores o efectos internos)
-      await Promise.all([
+      // 3) Módulos locales (cargas paralelas)
+      const [
+        { RULESETS },
+        { RegulationEngines },
+        { I18N },
+        shipsMod,
+        navalMod,
+        { default: App },
+        // evaluadores que App necesita por props:
+        { default: evaluateLRShips, evaluateGroups: evaluateLRShipsGroups },
+        { default: evaluateLRNavalShips, evaluateGroups: evaluateLRNavalGroups },
+      ] = await Promise.all([
+        import('./rulesets/index.js'),
+        import('./engines.js'),
+        import('./i18n/index.js'),
+        import('./dist/data/lr_ships_mech_joints.js'),
+        import('./dist/data/lr_naval_ships_mech_joints.js'),
+        import('./app-multi.js'),
         import('./dist/engine/lrShips.js'),
         import('./dist/engine/evaluateLRNavalShips.js'),
       ]);
 
-      // 5) Montaje (un único render)
+      // 4) Montaje
       const createRoot = (ReactDOM.createRoot || ReactDOM.default?.createRoot);
       if (!createRoot) throw new Error('ReactDOM.createRoot no disponible');
 
       createRoot(rootEl).render(
         html`<${App}
+          React=${React}
           html=${html}
           RULESETS=${RULESETS}
           RegulationEngines=${RegulationEngines}
           I18N=${I18N}
+          evaluateLRShips=${evaluateLRShips}
+          evaluateLRShipsGroups=${evaluateLRShipsGroups}
+          evaluateLRNavalShips=${evaluateLRNavalShips}
+          evaluateLRNavalGroups=${evaluateLRNavalGroups}
           ships=${shipsMod.default}
           naval=${navalMod.default}
         />`


### PR DESCRIPTION
## Summary
- update the asesor grip type multi HTML bootstrap to import React, HTM, and local modules in parallel
- pass React and evaluation helpers as props when mounting the application

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfd57347388321ad49945a44e3f81b