### PR TITLE
Match landing hero logo layout to header style

### DIFF
--- a/asesor-grip-type-multi.html
+++ b/asesor-grip-type-multi.html
@@ -393,5 +393,19 @@
       console.error(err);
     }
   </script>
+
+  <footer class="mt-16">
+    <div class="max-w-6xl mx-auto px-6">
+      <div class="rounded-2xl bg-slate-900/70 border border-slate-700 p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between shadow-[0_8px_40px_rgba(0,0,0,0.35)]">
+        <p class="text-slate-200 text-sm">
+          Por <strong>Jhon Eric Gomez</strong> – DVMPR-GEDIN
+        </p>
+        <p class="text-slate-200 text-sm mt-1 sm:mt-0">
+          Para consultas contactar a:
+          <a href="mailto:jegomez@cotecmar.com" class="text-sky-300 hover:text-sky-200 underline underline-offset-4">jegomez@cotecmar.com</a>.
+        </p>
+      </div>
+    </div>
+  </footer>
   </body>
 </html>

--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -340,12 +340,30 @@
   }
   .tbl tr:first-child td { border-top: none; }
   .small strong { color: #fff; }
-  footer {
-    margin-top: 32px;
-    font-size: 13px;
-    color: var(--mut);
-    line-height: 1.6;
-    text-align: center;
+  .mt-16 { margin-top: 4rem; }
+  .max-w-6xl { max-width: 72rem; }
+  .mx-auto { margin-left: auto; margin-right: auto; }
+  .px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+  .rounded-2xl { border-radius: 1rem; }
+  .bg-slate-900\/70 { background-color: rgba(15, 23, 42, 0.7); }
+  .border { border: 1px solid transparent; }
+  .border-slate-700 { border-color: #334155; }
+  .p-4 { padding: 1rem; }
+  .flex { display: flex; }
+  .flex-col { flex-direction: column; }
+  .text-slate-200 { color: #e2e8f0; }
+  .text-sm { font-size: 0.875rem; }
+  .mt-1 { margin-top: 0.25rem; }
+  .text-sky-300 { color: #7dd3fc; }
+  .underline { text-decoration: underline; }
+  .underline-offset-4 { text-underline-offset: 4px; }
+  .hover\:text-sky-200:hover { color: #bae6fd; }
+  .shadow-\[0_8px_40px_rgba\(0,0,0,0\.35\)\] { box-shadow: 0 8px 40px rgba(0, 0, 0, 0.35); }
+  @media (min-width: 640px) {
+    .sm\:flex-row { flex-direction: row; }
+    .sm\:items-center { align-items: center; }
+    .sm\:justify-between { justify-content: space-between; }
+    .sm\:mt-0 { margin-top: 0; }
   }
   /* Modal genérico para el evaluador LR de juntas */
   .lrj-modal {
@@ -482,9 +500,6 @@
     </div>
   </div>
 
-  <footer>
-    <p>Por Jhon Eric Gomez - DVMPR-GEDIN<br />Para consultas contactar a: <a href="mailto:jegomez@cotecmar.com">jegomez@cotecmar.com</a>.</p>
-  </footer>
 </div>
 
 <script>
@@ -1447,6 +1462,20 @@ window.addEventListener('DOMContentLoaded',()=>{
   cleanseLegacyTableRefs();
 });
 </script>
+
+<footer class="mt-16">
+  <div class="max-w-6xl mx-auto px-6">
+    <div class="rounded-2xl bg-slate-900/70 border border-slate-700 p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between shadow-[0_8px_40px_rgba(0,0,0,0.35)]">
+      <p class="text-slate-200 text-sm">
+        Por <strong>Jhon Eric Gomez</strong> – DVMPR-GEDIN
+      </p>
+      <p class="text-slate-200 text-sm mt-1 sm:mt-0">
+        Para consultas contactar a:
+        <a href="mailto:jegomez@cotecmar.com" class="text-sky-300 hover:text-sky-200 underline underline-offset-4">jegomez@cotecmar.com</a>.
+      </p>
+    </div>
+  </div>
+</footer>
 </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -39,55 +39,9 @@
     }
     .grid{
       display:grid;
-      grid-template-columns: minmax(0,1fr) minmax(0,1fr);
       gap:22px;
       margin-top:26px;
-    }
-    .card{
-      background:var(--panel-soft);
-      border-radius:var(--radius);
-      padding:28px;
-      border:1px solid var(--ring);
-      box-shadow: var(--shadow);
-    }
-    .card h2{
-      margin:0 0 12px;
-      font-size: clamp(22px, 2.6vw, 30px);
-      letter-spacing:-.01em;
-    }
-    .card p{
-      margin:0 0 18px;
-      color:var(--ink-soft);
-      line-height:1.6;
-      font-size:16px;
-    }
-    .actions{margin-top:18px}
-    .btn{
-      display:inline-flex;
-      align-items:center;
-      justify-content:center;
-      gap:10px;
-      padding:16px 22px;
-      border-radius:999px;
-      color:#0b1220;
-      font-weight:600;
-      text-decoration:none;
-      border:0;
-      cursor:pointer;
-      transition: transform .08s ease, box-shadow .2s ease, filter .2s ease;
-      box-shadow: 0 10px 30px rgba(0,0,0,.25);
-    }
-    .btn:hover{transform: translateY(-1px); filter: brightness(1.02)}
-    .btn:active{transform: translateY(0)}
-    /* Azul (como el primario de compatibilidad) */
-    .btn-primary{
-      background: linear-gradient(135deg, #06b6d4 0%, #3b82f6 100%);
-      color:#061120;
-    }
-    /* Morado/rosa (como la tarjeta del asesor) */
-    .btn-alt{
-      background: linear-gradient(135deg, #a855f7 0%, #ec4899 100%);
-      color:#0e1220;
+      grid-template-columns:repeat(1,minmax(0,1fr));
     }
     .eyebrow{
       font-size:12px;
@@ -97,62 +51,130 @@
       margin-bottom:8px;
       display:inline-block;
     }
-    .card .eyebrow{margin-bottom:10px}
-    .brand{
-      display:flex;
-      align-items:center;
-      gap:12px;
-      margin-top:10px;
-      color:var(--mut);
-      font-size:13px;
+    .tool-card .eyebrow{margin-bottom:10px}
+    .max-w-6xl{max-width:72rem;}
+    .mx-auto{margin-left:auto;margin-right:auto;}
+    .px-6{padding-left:1.5rem;padding-right:1.5rem;}
+    .text-4xl{font-size:clamp(2.25rem,5vw,2.9rem);}
+    .font-extrabold{font-weight:800;}
+    .text-slate-100{color:#f1f5f9;}
+    .text-slate-300{color:rgba(203,213,225,.92);}
+    .max-w-3xl{max-width:48rem;}
+    .mt-3{margin-top:.75rem;}
+    .hero{display:flex;align-items:flex-start;justify-content:space-between;gap:24px;flex-wrap:wrap;}
+    .hero-copy{flex:1 1 380px;min-width:260px;}
+    .hero-brand{flex:0 0 auto;display:flex;align-items:flex-start;justify-content:flex-end;padding:12px;border-radius:22px;background:rgba(15,23,42,.5);box-shadow:0 18px 40px rgba(3,10,28,.45);backdrop-filter:blur(12px);}
+    .hero-brand img{width:72px;height:72px;border-radius:16px;display:block;}
+    .gap-6{gap:1.5rem;}
+    .items-stretch{align-items:stretch;}
+    .tool-card{display:flex;flex-direction:column;height:100%;box-shadow:var(--shadow);}
+    .tool-card p{margin:0 0 18px;color:var(--ink-soft);line-height:1.6;font-size:16px;}
+    .tool-card .cta{margin-top:auto;}
+    .card-head{min-height:4.5rem;}
+    .btn-eval{
+      display:inline-flex;align-items:center;justify-content:center;
+      padding:.625rem 1.25rem;border-radius:1rem;font-weight:600;
+      color:#0a1220;background:linear-gradient(90deg,#21c8f6,#637bff);
+      box-shadow:0 6px 24px rgba(3,13,38,.35);transition:filter .2s ease;
+      text-decoration:none;
     }
-    .brand img{width:44px;height:44px;border-radius:12px;object-fit:cover;box-shadow:var(--shadow)}
-    @media (max-width:940px){
-      .grid{grid-template-columns:1fr}
+    .btn-eval:hover{filter:brightness(1.05);}
+    .rounded-3xl{border-radius:1.5rem;}
+    .rounded-2xl{border-radius:1rem;}
+    .border{border:1px solid transparent;}
+    .border-slate-700\/60{border-color:rgba(51,65,85,.6);}
+    .border-slate-700{border-color:#334155;}
+    .bg-slate-900\/40{background-color:rgba(15,23,42,.4);}
+    .bg-slate-900\/70{background-color:rgba(15,23,42,.7);}
+    .p-6{padding:1.5rem;}
+    .p-4{padding:1rem;}
+    .pt-4{padding-top:1rem;}
+    .text-2xl{font-size:1.5rem;}
+    .leading-tight{line-height:1.25;}
+    .text-slate-200{color:#e2e8f0;}
+    .text-sm{font-size:.875rem;}
+    .mt-1{margin-top:.25rem;}
+    .mt-16{margin-top:4rem;}
+    .flex{display:flex;}
+    .flex-col{flex-direction:column;}
+    .shadow-\[0_8px_40px_rgba\(0,0,0,0\.35\)\]{box-shadow:0 8px 40px rgba(0,0,0,.35);}
+    .text-sky-300{color:#7dd3fc;}
+    .underline{text-decoration:underline;}
+    .underline-offset-4{text-underline-offset:4px;}
+    .hover\:text-sky-200:hover{color:#bae6fd;}
+    .btn-eval:focus{outline:2px solid rgba(99,123,255,.4);outline-offset:2px;}
+    @media (min-width:640px){
+      .sm\:block{display:block;}
+      .sm\:flex-row{flex-direction:row;}
+      .sm\:items-center{align-items:center;}
+      .sm\:justify-between{justify-content:space-between;}
+      .sm\:mt-0{margin-top:0;}
+    }
+    @media (min-width:768px){
+      .md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr));}
+      .md\:text-5xl{font-size:3rem;}
     }
   </style>
 </head>
 <body>
   <div class="wrap">
     <span class="eyebrow">Herramientas</span>
-    <h1>Herramientas normativas para sistemas de tuberías</h1>
-    <p class="sublead">
-      Accede a los asistentes interactivos desarrollados para comprobar requisitos reglamentarios en buques.
-      Elige la función que necesitas: compatibilidad de tuberías que atraviesan tanques y espacios, o el
-      asesor para juntas flexibles tipo Grip (Slip-on) según LR Naval Ships / LR Ships.
-    </p>
+    <section class="hero max-w-6xl mx-auto px-6">
+      <div class="hero-copy">
+        <h1 class="text-4xl md:text-5xl font-extrabold text-slate-100">
+          Herramientas normativas para sistemas de tuberías
+        </h1>
+        <p class="mt-3 text-slate-300 max-w-3xl">
+          Accede a los asistentes interactivos desarrollados para comprobar requisitos reglamentarios en buques.
+          Elige la función que necesitas: compatibilidad de tuberías que atraviesan tanques y espacios, o el
+          asesor para juntas flexibles tipo Grip (Slip-on) según LR Naval Ships / LR Ships.
+        </p>
+      </div>
+      <div class="hero-brand">
+        <img src="assets/joints/cotec.jpg" alt="COTECMAR" />
+      </div>
+    </section>
 
-    <div class="grid">
-      <!-- Tarjeta 1 -->
-      <section class="card">
+    <div class="grid gap-6 md:grid-cols-2 items-stretch">
+      <!-- TARJETA IZQUIERDA -->
+      <article class="tool-card rounded-3xl border border-slate-700/60 bg-slate-900/40 p-6">
         <span class="eyebrow">GL · TABLA 11.5</span>
-        <h2>Evaluador De Pasos De Tuberias En Diferentes Espacios</h2>
+        <h3 class="card-head text-2xl font-extrabold leading-tight">Evaluador de pasos de tuberías en diferentes espacios</h3>
         <p>
           Versión sin dependencias adicionales, pensada para pruebas o dispositivos lentos. Calcula compatibilidad de paso
           a través de <b>tanques y espacios</b> y presenta el <b>espesor mínimo</b> por material.
         </p>
-        <div class="actions">
-          <a class="btn btn-alt" href="compatibilidad.html">Abrir evaluador</a>
+        <div class="cta pt-4">
+          <a href="compatibilidad.html" class="btn-eval">Abrir evaluador</a>
         </div>
-      </section>
+      </article>
 
-      <!-- Tarjeta 2 -->
-      <section class="card">
+      <!-- TARJETA DERECHA -->
+      <article class="tool-card rounded-3xl border border-slate-700/60 bg-slate-900/40 p-6">
         <span class="eyebrow">LR SHIPS · LR NAVAL</span>
-        <h2>Evaluador Multi-noma (LR Ships / LR Naval) Para Selección De Juntas</h2>
+        <h3 class="card-head text-2xl font-extrabold leading-tight">Evaluador multi-norma (LR Ships / LR Naval) para selección de juntas</h3>
         <p>
           Analiza compatibilidad por <b>sistema</b>, <b>ubicación</b>, <b>clase</b> y <b>OD</b>. Incluye visor de subtipos e imágenes.
         </p>
-        <div class="actions">
-          <a class="btn btn-primary" href="asesor-grip-type-multi.html">Abrir evaluador</a>
+        <div class="cta pt-4">
+          <a href="asesor-grip-type-multi.html" class="btn-eval">Abrir evaluador</a>
         </div>
-      </section>
-    </div>
-
-    <div class="brand">
-      <img src="assets/joints/cotec.jpg" alt="COTECMAR">
-      <span>Desarrollado para COTECMAR · DVMPR-GEDIN</span>
+      </article>
     </div>
   </div>
+
+  <footer class="mt-16">
+    <div class="max-w-6xl mx-auto px-6">
+      <div class="rounded-2xl bg-slate-900/70 border border-slate-700 p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between shadow-[0_8px_40px_rgba(0,0,0,0.35)]">
+        <p class="text-slate-200 text-sm">
+          Por <strong>Jhon Eric Gomez</strong> – DVMPR-GEDIN
+        </p>
+        <p class="text-slate-200 text-sm mt-1 sm:mt-0">
+          Para consultas contactar a:
+          <a href="mailto:jegomez@cotecmar.com" class="text-sky-300 hover:text-sky-200 underline underline-offset-4">jegomez@cotecmar.com</a>.
+        </p>
+      </div>
+    </div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adjust the Cotecmar badge positioning in the landing hero so it sits farther from the heading text
- wrap the landing hero heading and logo into a flex layout with a branded badge block matching the compatibility header spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfd9e0c14883219c97b5a19d40bf66