### PR TITLE
Align hero sections with unified logo styling

### DIFF
--- a/app-multi.js
+++ b/app-multi.js
@@ -934,23 +934,24 @@ export default function App({
   return html`
     <div className="pb-16">
       <section className="relative hero-pr max-w-6xl mx-auto px-6 py-10">
-        <div className="logo-badge" aria-hidden="true">
+        <div className="logo-badge" aria-hidden="true" role="presentation">
           <img src="assets/joints/cotec.jpg" alt="COTECMAR" />
         </div>
 
         <p className="uppercase tracking-[0.4em] text-xs text-sky-400">LR · Juntas mecánicas</p>
-        <h1 className="hero-title h1-two-lines font-extrabold">
-          Evaluador multi-norma para juntas mecánicas Grip-Type / Slip-on
+
+        <h1 className="hero-title font-extrabold">
+          Evaluador multi-norma para juntas<br className="hidden xl:block" />
+          mecánicas Grip-Type / Slip-on
         </h1>
+
         <p className="mt-3 text-slate-300 max-w-3xl">
           Selecciona el reglamento LR aplicable, el sistema de tuberías y los parámetros de diseño
           para evaluar la compatibilidad de uniones mecánicas tipo Grip/Slip y sus alternativas.
         </p>
         <div className="mt-4 flex flex-wrap gap-3 text-sm text-slate-300">
-          <span className="inline-flex items-center gap-2"><${ShieldIcon} className="w-5 h-5 text-emerald-300" />
-            Flujo unificado por norma (patrón estrategia)</span>
-          <span className="inline-flex items-center gap-2"><${ShieldIcon} className="w-5 h-5 text-sky-300" />
-            Datos y notas aislados por conjunto de reglas</span>
+          <span className="inline-flex items-center gap-2"><${ShieldIcon} className="w-5 h-5 text-emerald-300" /> Flujo unificado por norma (patrón estrategia)</span>
+          <span className="inline-flex items-center gap-2"><${ShieldIcon} className="w-5 h-5 text-sky-300" /> Datos y notas aislados por conjunto de reglas</span>
         </div>
       </section>
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -24,7 +24,7 @@ h3 { margin:0 0 8px; }
 
 body.modal-open { overflow: hidden; }
 
-/* Logo homogéneo */
+/* Logo homogéneo, arriba-derecha */
 .logo-badge{
   position:absolute; right:24px; top:-6px;
   width:88px; height:88px; border-radius:16px;
@@ -34,7 +34,7 @@ body.modal-open { overflow: hidden; }
 }
 .logo-badge img{ width:68%; height:68%; object-fit:contain; filter: drop-shadow(0 2px 8px rgba(0,0,0,.35)); }
 
-/* Reserva para que el H1 no choque con el logo */
+/* Reserva lateral para que el H1 no choque con el logo */
 .hero-pr{ padding-right:120px; }
 @media (max-width:1024px){ .hero-pr{ padding-right:100px; } }
 @media (max-width:640px){
@@ -42,28 +42,19 @@ body.modal-open { overflow: hidden; }
   .hero-pr{ padding-right:84px; }
 }
 
-/* Tipografía homogénea + forzar 2 líneas */
+/* Títulos del héroe (sin cortes raros) */
 .hero-title{
   line-height:1.1; letter-spacing:-0.01em; color:#f8fafc;
-  text-wrap: balance;
+  text-wrap: balance;      /* reparte el texto en 2 líneas de forma estética */
+  hyphens: none;           /* evita "ubi-ción" */
+  word-break: normal;      /* no romper palabras */
 }
-.h1-two-lines{ max-width: 52ch; }
+.h1-two-lines{ max-width: 52ch; }  /* ayuda a mantener ~2 líneas en desktop */
 
-/* Footer centrado y con contraste */
-.site-footer{ margin-top:4rem; }
-.site-footer .footer-wrap{
-  max-width:64rem; margin:0 auto; padding:.875rem 1.25rem;
-  border-radius:14px; text-align:center;
-  background:rgba(11,17,28,.55); border:1px solid rgba(148,163,184,.25);
-  color:#e5e7eb;
-}
-.site-footer a{ color:#7dd3fc; text-decoration:underline; text-underline-offset:4px; }
-
-/* ————— Cards: alinear botones al fondo ————— */
+/* Cards: alinear botones abajo y unificar estilo */
 .tool-card{ display:flex; flex-direction:column; height:100%; }
 .tool-card .tool-cta{ margin-top:auto; }
 
-/* ————— Botón formal (azul institucional) ————— */
 .btn-eval{
   display:inline-flex; align-items:center; justify-content:center;
   padding:.625rem 1.25rem; border-radius:1rem; font-weight:600;
@@ -72,4 +63,14 @@ body.modal-open { overflow: hidden; }
   text-decoration:none;
 }
 .btn-eval:hover{ filter:brightness(1.06); }
+
+/* Footer centrado y homogéneo */
+.site-footer{ margin-top:4rem; }
+.site-footer .footer-wrap{
+  max-width:64rem; margin:0 auto; padding:.875rem 1.25rem;
+  border-radius:14px; text-align:center;
+  background:rgba(11,17,28,.55); border:1px solid rgba(148,163,184,.25);
+  color:#e5e7eb;
+}
+.site-footer a{ color:#7dd3fc; text-decoration:underline; text-underline-offset:4px; }
 

--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -413,12 +413,13 @@
 <div class="wrap">
   <nav><a href="index.html">← Volver al inicio</a></nav>
   <section class="relative hero-pr max-w-6xl mx-auto px-6">
-    <div class="logo-badge" aria-hidden="true">
+    <div class="logo-badge" aria-hidden="true" role="presentation">
       <img src="assets/joints/cotec.jpg" alt="COTECMAR">
     </div>
 
     <h1 class="hero-title h1-two-lines font-extrabold">
-      ¿Puede pasar una <em>tubería</em> a través de una <em>ubicación</em>?
+      ¿Puede pasar una <em>tubería</em> a través de una<br class="hidden lg:block">
+      <em>ubicación</em>?
     </h1>
     <p id="pageSublead" class="sublead block-subtitle mt-3 text-slate-300 max-w-3xl">
       Basado en norma GL para compatibilidad de rutas de tuberías; para agua potable se

--- a/index.html
+++ b/index.html
@@ -112,13 +112,13 @@
   <div class="wrap">
     <span class="eyebrow">Herramientas</span>
     <section class="relative hero-pr max-w-6xl mx-auto px-6">
-      <div class="logo-badge" aria-hidden="true">
+      <div class="logo-badge" aria-hidden="true" role="presentation">
         <img src="assets/joints/cotec.jpg" alt="COTECMAR">
       </div>
 
       <h1 class="hero-title h1-two-lines font-extrabold">
-        Herramientas normativas para<br class="hidden 2xl:block">
-        sistemas de tuberías
+        Herramientas normativas para sistemas de<br class="hidden lg:block">
+        tuberías
       </h1>
 
       <p class="mt-3 text-slate-300 max-w-3xl">


### PR DESCRIPTION
## Summary
- add shared hero, card, button, and footer refinements to the global stylesheet
- update the landing and compatibility pages to use the new hero layout, logo asset, and centered footer
- align the multi-norma React hero section with the unified structure and logo image

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff6298e208321bb5581daede3e79f