### PR TITLE
Adjust landing evaluator button gradients

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -59,9 +59,15 @@ body.modal-open { overflow: hidden; }
 .btn-eval{
   display:inline-flex; align-items:center; justify-content:center;
   padding:.625rem 1.25rem; border-radius:1rem; font-weight:600;
-  color:#0a1220; background:linear-gradient(90deg,#21c8f6,#637bff);
+  color:#041223; background:linear-gradient(96deg,#33c6ff,#6e9cff);
   box-shadow:0 6px 24px rgba(3,13,38,.35); transition:filter .2s ease;
   text-decoration:none;
+}
+.tool-card--compat .btn-eval{
+  background:linear-gradient(105deg,#3bd9ff 0%,#8df9ff 100%);
+}
+.tool-card--multi .btn-eval{
+  background:linear-gradient(105deg,#8cb5ff 0%,#597bff 100%);
 }
 .btn-eval:hover{ filter:brightness(1.06); }
 

--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
     .gap-6{gap:1.5rem;}
     .items-stretch{align-items:stretch;}
     .tool-card{display:flex;flex-direction:column;height:100%;box-shadow:var(--shadow);}
+    .tool-card--compat{background-color:rgba(147,197,253,.32);}
+    .tool-card--multi{background-color:rgba(125,211,252,.32);}
     .tool-card p{margin:0 0 18px;color:var(--ink-soft);line-height:1.6;font-size:16px;}
     .card-head{min-height:4.5rem;}
     .rounded-3xl{border-radius:1.5rem;}
@@ -130,7 +132,7 @@
 
     <div class="grid gap-6 md:grid-cols-2 items-stretch">
       <!-- TARJETA IZQUIERDA -->
-      <article class="tool-card rounded-3xl border border-slate-700/60 bg-slate-900/40 p-6">
+      <article class="tool-card tool-card--compat rounded-3xl border border-slate-700/60 bg-slate-900/40 p-6">
         <span class="eyebrow">GL · TABLA 11.5</span>
         <h3 class="card-head text-2xl font-extrabold leading-tight">Evaluador de pasos de tuberías en diferentes espacios</h3>
         <p>
@@ -143,7 +145,7 @@
       </article>
 
       <!-- TARJETA DERECHA -->
-      <article class="tool-card rounded-3xl border border-slate-700/60 bg-slate-900/40 p-6">
+      <article class="tool-card tool-card--multi rounded-3xl border border-slate-700/60 bg-slate-900/40 p-6">
         <span class="eyebrow">LR SHIPS · LR NAVAL</span>
         <h3 class="card-head text-2xl font-extrabold leading-tight">Evaluador multi-norma (LR Ships / LR Naval) para selección de juntas</h3>
         <p>


### PR DESCRIPTION
## Summary
- refresh the default Abrir evaluador button gradient with a softer blue base
- add distinct gradient treatments for the compatibilidad and multi-norma tool buttons to differentiate them without magenta tones

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e07347a9f4832184d3d2b230b37d8a