### PR TITLE
Update compatibility validation button styling

### DIFF
--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -181,20 +181,37 @@
   }
   #daSelect { width: 100%; }
   .btn-primary {
-    background: linear-gradient(135deg, var(--accent), #0ea5e9);
-    color: #0b1120;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background: #0ea5e9;
+    color: #041628;
     font-weight: 600;
-    font-size: 14px;
-    padding: 10px 18px;
-    border-radius: 999px;
+    font-size: 15px;
+    padding: 12px 26px;
+    border-radius: 12px;
     border: none;
     cursor: pointer;
     box-shadow: 0 12px 30px rgba(14, 165, 233, 0.28);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   }
   .btn-primary:hover {
     transform: translateY(-2px);
+    background: #38bdf8;
     box-shadow: 0 14px 34px rgba(14, 165, 233, 0.35);
+  }
+  .btn-primary:focus-visible {
+    outline: 2px solid rgba(56, 189, 248, 0.5);
+    outline-offset: 3px;
+  }
+  .btn-primary .btn-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .btn-primary .btn-icon svg {
+    width: 18px;
+    height: 18px;
   }
   .hint {
     font-size: 12px;
@@ -463,7 +480,14 @@
           <label for="daSelect">Diámetro exterior d<sub>a</sub> (dependiente de Material)</label>
           <select id="daSelect"></select>
           <div class="row da-actions">
-            <button id="btnDaValidate" type="button" class="btn-primary">Validar</button>
+            <button id="btnDaValidate" type="button" class="btn-primary">
+              <span class="btn-icon" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m1.1-4.4a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0z" />
+                </svg>
+              </span>
+              <span>Evaluar compatibilidad</span>
+            </button>
             <small id="daHelp" class="hint"></small>
           </div>
           <div class="hint">El espesor s se calcula según el intervalo [mín, máx] en la tabla del material.</div>


### PR DESCRIPTION
## Summary
- restyled the compatibility validation button to use a rectangular blue design with better hover and focus feedback
- added an inline magnifier icon and updated copy to match the new button appearance

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0801cb67c8321be7455100cee000b