### PR TITLE
Adjust manual mode field order for pipe class selection

### DIFF
--- a/app-multi.js
+++ b/app-multi.js
@@ -1048,29 +1048,37 @@ export default function App({
                     <option value="III">Clase III</option>
                   </select>
                 </label>
+
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="text-slate-300">Diámetro nominal - OD</span>
+                  <select
+                    className="bg-slate-900/60 border border-slate-700 rounded-lg px-3 py-2"
+                    value=${odMM ?? ''}
+                    onChange=${(e) => {
+                      const value = e.target.value;
+                      setOdMM(value ? parseFloat(value) : null);
+                      markPendingChanges();
+                    }}
+                  >
+                    <option value="" disabled>Selecciona un diámetro...</option>
+                    ${SCHEDULES.map((opt) => html`
+                      <option key=${opt.od} value=${opt.od}>${opt.label}</option>
+                    `)}
+                  </select>
+                </label>
               `
-            : null}
+            : html`
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="text-slate-300">Temperatura de diseño (°C)</span>
+                  <input
+                    type="number"
+                    step="1"
+                    className="bg-slate-900/60 border border-slate-700 rounded-lg px-3 py-2"
+                    value=${designTemperatureC}
+                    onChange=${(e) => { setDesignTemperatureC(parseFloat(e.target.value)); markPendingChanges(); }}
+                  />
+                </label>
 
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="text-slate-300">Diámetro nominal - OD</span>
-            <select
-              className="bg-slate-900/60 border border-slate-700 rounded-lg px-3 py-2"
-              value=${odMM ?? ''}
-              onChange=${(e) => {
-                const value = e.target.value;
-                setOdMM(value ? parseFloat(value) : null);
-                markPendingChanges();
-              }}
-            >
-              <option value="" disabled>Selecciona un diámetro...</option>
-              ${SCHEDULES.map((opt) => html`
-                <option key=${opt.od} value=${opt.od}>${opt.label}</option>
-              `)}
-            </select>
-          </label>
-
-          ${classMode === 'auto'
-            ? html`
                 <label className="flex flex-col gap-1 text-sm">
                   <span className="text-slate-300">Presión de diseño (bar)</span>
                   <input
@@ -1083,17 +1091,23 @@ export default function App({
                 </label>
 
                 <label className="flex flex-col gap-1 text-sm">
-                  <span className="text-slate-300">Temperatura de diseño (°C)</span>
-                  <input
-                    type="number"
-                    step="1"
+                  <span className="text-slate-300">Diámetro nominal - OD</span>
+                  <select
                     className="bg-slate-900/60 border border-slate-700 rounded-lg px-3 py-2"
-                    value=${designTemperatureC}
-                    onChange=${(e) => { setDesignTemperatureC(parseFloat(e.target.value)); markPendingChanges(); }}
-                  />
+                    value=${odMM ?? ''}
+                    onChange=${(e) => {
+                      const value = e.target.value;
+                      setOdMM(value ? parseFloat(value) : null);
+                      markPendingChanges();
+                    }}
+                  >
+                    <option value="" disabled>Selecciona un diámetro...</option>
+                    ${SCHEDULES.map((opt) => html`
+                      <option key=${opt.od} value=${opt.od}>${opt.label}</option>
+                    `)}
+                  </select>
                 </label>
-              `
-            : null}
+              `}
           </div>
 
           <div className="mt-6 flex flex-wrap items-center gap-3 form-actions">


### PR DESCRIPTION
## Summary
- swap the manual mode form layout so the design temperature field now precedes pressure and diameter
- render the diameter selector after the temperature input when manual mode is active for clearer workflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e19dae7de083219e0a8e476eae1455