### PR TITLE
Harden forbidden joint cards in UI

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6,14 +6,42 @@ label { margin-right:12px; }
 .card { border-radius:12px; padding:16px; background:#151b2f; border:2px solid transparent; }
 .card.allowed { border-color:#10b981; }
 .card.conditional { border-color:#f59e0b; }
-.card.forbidden { border-color:#ef4444; opacity:.8; }
+.card.forbidden {
+  position:relative;
+  border:2px solid #b91c1c;
+  background:#fee2e2;
+  color:#7f1d1d;
+}
+.card.forbidden .tag { background:rgba(185,28,28,0.18); color:#7f1d1d; }
+.card.forbidden .tag.note { color:#7f1d1d; }
+.card.forbidden .subtype-label {
+  text-decoration:line-through;
+  opacity:0.75;
+}
+.card.forbidden::after {
+  content:"";
+  position:absolute;
+  inset:0;
+  background:repeating-linear-gradient(45deg, rgba(185,28,28,0.12) 0 12px, transparent 12px 24px);
+  pointer-events:none;
+  border-radius:inherit;
+}
+.subtype.disabled {
+  opacity:0.8;
+}
 .tag { display:inline-block; margin:4px 6px 0 0; padding:2px 8px; border-radius:999px; background:#27304a; font-size:12px; }
+.tag.danger { background:#b91c1c; color:#fff; }
 .subtype { display:flex; align-items:center; justify-content:space-between; gap:12px; }
 .subtype-label { display:flex; align-items:center; gap:8px; }
 .subtype .dot { width:10px; height:10px; border-radius:50%; background:#ef4444; }
 .subtype.valid .dot { background:#10b981; }
 .subtype-invalid { font-size:12px; opacity:.75; }
 .ver-btn { background:#1d253d; color:#93c5fd; border:1px solid #1e3a8a; border-radius:999px; padding:4px 12px; font-size:12px; letter-spacing:.05em; text-transform:uppercase; cursor:pointer; transition:background .2s ease, color .2s ease; }
+.ver-btn.disabled {
+  opacity:0.5;
+  pointer-events:none;
+  cursor:not-allowed;
+}
 .ver-btn:hover { background:#2563eb; color:#0f172a; }
 h3 { margin:0 0 8px; }
 .img-modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.8);z-index:9999}

--- a/assets/js/joint-viewer.js
+++ b/assets/js/joint-viewer.js
@@ -45,6 +45,9 @@ function closeImageModal() {
 export function wireViewButtons(root = document) {
   root.querySelectorAll('[data-action="view-joint"]').forEach((btn) => {
     btn.addEventListener("click", () => {
+      if (btn.classList.contains("disabled") || btn.getAttribute("aria-disabled") === "true") {
+        return;
+      }
       const id = btn.dataset.subtypeId;
       const name = btn.dataset.subtypeName || btn.textContent.trim();
       openImageModal(getJointImageSrc(id), name);

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -21,22 +21,32 @@ export function renderUI({ row, result }) {
       ${ev.reasons.length ? `<div style="margin-top:8px">Motivos:<br>${ev.reasons.map(r=>`• ${r}`).join("<br>")}</div>` : ""}
       ${clauseList.length ? `<div style="margin-top:8px">Cláusulas: ${clauseList.map(c=>`<span class="tag clause">${c}</span>`).join(" ")}</div>` : ""}
       ${noteList.length ? `<div style="margin-top:8px">Notas de referencia: ${noteList.map(n=>`<span class="tag note">Nota ${n}</span>`).join(" ")}</div>` : ""}
+      ${(ev.status==="forbidden" && (ev.reasons.some(r=>/Nota\s*2/i.test(r)) || noteList.includes(2)))
+        ? `<div style="margin-top:8px"><span class="tag danger">Prohibido por Nota 2</span></div>`
+        : ""}
       <div style="margin-top:8px">Subtipos:</div>
-      <div>${ev.subtypes.map(s=>`
-        <div class="subtype ${s.valid ? 'valid' : ''}">
-          <div class="subtype-label">
-            <span class="dot"></span>
-            <span>${s.name}</span>
-            ${s.valid ? '' : '<span class="subtype-invalid">(no válido por clase/OD)</span>'}
-          </div>
-          <button class="ver-btn" type="button"
-                  data-action="view-joint"
-                  data-subtype-id="${s.id}"
-                  data-subtype-name="${s.name}">
-            VER
-          </button>
-        </div>`).join("")}
-      </div>
+      <div>${
+        ev.subtypes.map(s=>{
+          const disabled = ev.status === "forbidden";
+          const btn = disabled
+            ? `<button class="ver-btn disabled" type="button" aria-disabled="true" title="No disponible: prohibido por nota/cláusula">VER</button>`
+            : `<button class="ver-btn" type="button"
+                        data-action="view-joint"
+                        data-subtype-id="${s.id}"
+                        data-subtype-name="${s.name}">
+                 VER
+               </button>`;
+          return `
+            <div class="subtype ${s.valid ? 'valid' : ''} ${disabled ? 'disabled' : ''}">
+              <div class="subtype-label">
+                <span class="dot"></span>
+                <span>${s.name}</span>
+                ${s.valid ? '' : '<span class="subtype-invalid">(no válido por clase/OD)</span>'}
+              </div>
+              ${btn}
+            </div>`;
+        }).join("")
+      }</div>
     `;
     cards.appendChild(el);
   });


### PR DESCRIPTION
## Summary
- mark forbidden joint cards and subtypes with red theming and disabled actions, including a "Nota 2" badge when applicable
- disable joint preview buttons when a group is forbidden and show a tooltip-style message
- prevent opening the joint modal when the button is disabled

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3fda560ec8321919c9391fc66f481