### PR TITLE
Add LR Naval advisor with rules and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 <body>
   <header>
     <div>
-      <h1>Asesor de juntas (LR Ships)</h1>
+      <h1>Asesor de juntas (LR Ships &amp; Naval)</h1>
       <p class="lead">Selecciona el sistema, espacio y clase para verificar qué tipos de junta slip-on o mecánica están permitidos según LR.</p>
     </div>
     <nav>
@@ -76,8 +76,10 @@
     </nav>
   </header>
   <main>
-    <div class="layout">
-      <form id="form-lr-ships">
+    <section>
+      <h2 style="margin:0 0 16px;">Guía LR Ships</h2>
+      <div class="layout">
+        <form id="form-lr-ships">
         <div class="form-row">
           <div>
             <label for="select-system">Sistema / Línea</label>
@@ -104,12 +106,57 @@
         </div>
         <button type="submit">Evaluar</button>
         <div class="helper" id="helper-text"></div>
-      </form>
-      <section class="cards-wrapper">
-        <h2 style="margin-top:0">Resultado</h2>
-        <div id="cards"></div>
-      </section>
-    </div>
+        </form>
+        <section class="cards-wrapper">
+          <h3 style="margin-top:0">Resultado</h3>
+          <div id="cards"></div>
+        </section>
+      </div>
+    </section>
+
+    <section>
+      <h2 style="margin:48px 0 16px 0;">Guía LR Naval</h2>
+      <div class="layout">
+        <form id="form-lr-naval">
+          <div class="form-row">
+            <div>
+              <label for="select-system-naval">Sistema / Línea</label>
+              <select id="select-system-naval" required></select>
+            </div>
+            <div>
+              <label for="select-space-naval">Espacio</label>
+              <select id="select-space-naval" required></select>
+            </div>
+          </div>
+          <div class="form-row">
+            <div>
+              <label for="select-class-naval">Clase de tubería</label>
+              <select id="select-class-naval" required>
+                <option value="I">Clase I</option>
+                <option value="II">Clase II</option>
+                <option value="III">Clase III</option>
+              </select>
+            </div>
+            <div>
+              <label for="input-od-naval">Diámetro exterior (mm)</label>
+              <input id="input-od-naval" type="number" min="1" step="0.1" placeholder="Ej. 60" required />
+            </div>
+          </div>
+          <div class="form-row" id="tank-same-wrapper" style="display:none;">
+            <label style="grid-column:1 / -1; display:flex; align-items:center; gap:8px; font-weight:500; font-size:0.95rem; letter-spacing:0; text-transform:none;">
+              <input type="checkbox" id="chk-tank-same" />
+              Medio dentro del tanque es el mismo que el del sistema
+            </label>
+          </div>
+          <button type="submit">Evaluar</button>
+          <div class="helper" id="helper-text-naval"></div>
+        </form>
+        <section class="cards-wrapper">
+          <h3 style="margin-top:0">Resultado</h3>
+          <div id="cards-naval"></div>
+        </section>
+      </div>
+    </section>
   </main>
 
   <dialog id="note-modal" class="modal">
@@ -123,6 +170,7 @@
 
   <script type="module">
     import { evaluateLRShips, getNoteText } from './rules-lr-ships.js';
+    import { evaluateLRNaval, getNavalNoteText } from './rules-lr-naval.js';
 
     const systemSelect = document.querySelector('#select-system');
     const spaceSelect = document.querySelector('#select-space');
@@ -130,6 +178,15 @@
     const odInput = document.querySelector('#input-od');
     const cardsHost = document.querySelector('#cards');
     const helperText = document.querySelector('#helper-text');
+
+    const navalSystemSelect = document.querySelector('#select-system-naval');
+    const navalSpaceSelect = document.querySelector('#select-space-naval');
+    const navalClassSelect = document.querySelector('#select-class-naval');
+    const navalOdInput = document.querySelector('#input-od-naval');
+    const navalCardsHost = document.querySelector('#cards-naval');
+    const navalHelperText = document.querySelector('#helper-text-naval');
+    const tankSameWrapper = document.querySelector('#tank-same-wrapper');
+    const tankSameCheckbox = document.querySelector('#chk-tank-same');
 
     const SPACES = [
       { value: 'machinery_category_A', label: 'Máquinas Categoría A' },
@@ -168,18 +225,18 @@
       }
     }
 
-    function renderCards(cards) {
-      cardsHost.innerHTML = '';
+    function renderToHost(host, cards, noteProvider) {
+      host.innerHTML = '';
       if (!cards.length) {
-        cardsHost.innerHTML = '<p class="muted">Sin resultados para la selección.</p>';
+        host.innerHTML = '<p class="muted">Sin resultados para la selección.</p>';
         return;
       }
       for (const card of cards) {
-        cardsHost.appendChild(cardNode(card));
+        host.appendChild(cardNode(card, noteProvider));
       }
     }
 
-    function cardNode(card) {
+    function cardNode(card, noteProvider) {
       const node = document.createElement('article');
       node.className = `card ${card.status === 'NO PERMITIDO' ? 'card--blocked' : ''}`;
       node.innerHTML = `
@@ -189,6 +246,7 @@
         </div>
         <div class="card__body">
           ${card.reason ? `<p class="muted">${card.reason}</p>` : ''}
+          ${card.fire_resistant_tag ? `<p class="muted">${card.fire_resistant_tag}</p>` : ''}
           ${card.fire_test ? `<p class="muted">${card.fire_test}</p>` : ''}
           ${notesChips(card.notes)}
           <button class="btn-see" ${card.status === 'NO PERMITIDO' ? 'disabled aria-disabled="true"' : ''}>VER</button>
@@ -197,7 +255,7 @@
       node.querySelectorAll('.note-chip').forEach(chip => {
         chip.addEventListener('click', () => {
           const id = chip.getAttribute('data-id');
-          const { es, en } = getNoteText(id);
+          const { es, en } = noteProvider(id);
           showNoteModal(`Nota ${id}`, es, en);
         });
       });
@@ -218,8 +276,19 @@
       modal.showModal();
     }
 
+    function renderCards(cards) {
+      renderToHost(cardsHost, cards, getNoteText);
+    }
+
+    function renderNaval(cards) {
+      renderToHost(navalCardsHost, cards, getNavalNoteText);
+    }
+
     fillSpaces();
     loadSystems();
+
+    fillNavalSpaces();
+    loadNavalSystems();
 
     document.querySelector('#form-lr-ships')?.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -234,6 +303,75 @@
       helperText.textContent = '';
       const { cards } = evaluateLRShips({ systemKey, spaceKey, klass, od_mm: od });
       renderCards(cards);
+    });
+
+    const NAVAL_SPACES = [
+      { value: 'machinery_category_A', label: 'Máquinas Categoría A' },
+      { value: 'accommodation', label: 'Acomodaciones' },
+      { value: 'munition_store', label: 'Pañol de municiones' },
+      { value: 'open_deck_low_fire_risk', label: 'Cubierta abierta (bajo riesgo de fuego)' },
+      { value: 'weather_deck', label: 'Weather deck' },
+      { value: 'cargo_hold', label: 'Bodega de carga' },
+      { value: 'tank_same_medium', label: 'Tanque (mismo medio)' },
+      { value: 'tank_other_medium', label: 'Tanque (otro medio)' },
+      { value: 'not_easily_accessible', label: 'Espacio de difícil acceso' },
+      { value: 'above_limit_watertight_integrity_only', label: 'Sobre límite de estanqueidad' }
+    ];
+
+    function fillNavalSpaces() {
+      if (!navalSpaceSelect) return;
+      navalSpaceSelect.innerHTML = '';
+      for (const item of NAVAL_SPACES) {
+        const opt = document.createElement('option');
+        opt.value = item.value;
+        opt.textContent = item.label;
+        navalSpaceSelect.appendChild(opt);
+      }
+      updateTankCheckbox();
+    }
+
+    async function loadNavalSystems() {
+      if (!navalSystemSelect) return;
+      const res = await fetch('./lr_naval.table_service.json');
+      const data = await res.json();
+      const rows = Array.isArray(data) ? data : Object.values(data);
+      const options = rows.filter(r => r?.key && r?.label_es).map(r => ({
+        value: r.key,
+        label: r.label_es
+      }));
+      navalSystemSelect.innerHTML = '';
+      for (const item of options) {
+        const opt = document.createElement('option');
+        opt.value = item.value;
+        opt.textContent = item.label;
+        navalSystemSelect.appendChild(opt);
+      }
+    }
+
+    function updateTankCheckbox() {
+      if (!navalSpaceSelect || !tankSameWrapper) return;
+      const value = navalSpaceSelect.value;
+      const isTank = value === 'tank_same_medium' || value === 'tank_other_medium';
+      tankSameWrapper.style.display = isTank ? 'block' : 'none';
+      if (!isTank && tankSameCheckbox) tankSameCheckbox.checked = false;
+    }
+
+    navalSpaceSelect?.addEventListener('change', updateTankCheckbox);
+
+    document.querySelector('#form-lr-naval')?.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const systemKey = navalSystemSelect?.value;
+      const spaceKey = navalSpaceSelect?.value;
+      const klass = navalClassSelect?.value;
+      const od = Number(navalOdInput?.value);
+      if (!systemKey || !spaceKey || !klass || !od) {
+        if (navalHelperText) navalHelperText.textContent = 'Completa todos los campos con valores válidos.';
+        return;
+      }
+      if (navalHelperText) navalHelperText.textContent = '';
+      const insideTankSame = Boolean(tankSameCheckbox?.checked);
+      const { cards } = evaluateLRNaval({ systemKey, spaceKey, klass, od_mm: od, inside_tank_medium_same: insideTankSame });
+      renderNaval(cards);
     });
   </script>
 </body>

--- a/lr_naval.notes.json
+++ b/lr_naval.notes.json
@@ -1,66 +1,90 @@
 {
-  "always_note_ids": [7],
-  "test_equivalence": {
-    "30min_dry": ["8dry_22wet", "30min_wet"],
-    "8dry_22wet": ["30min_wet"]
-  },
+  "schema": "lr_naval.notes.v1",
   "space_rules": [
     {
       "note_ids": [2],
       "refs": ["Note 2"],
-      "applies_if_space_in": ["machinery_category_A","accommodation","munition_store"],
-      "forbid_joints": ["slip_on.machine_grooved","slip_on.grip","slip_on.slip"]
-    },
-    {
-      "note_ids": [2],
-      "refs": ["Note 2"],
-      "applies_if_space_in": ["machinery_other"],
-      "advisory": "Slip-on permitido en otros espacios de máquinas si está visible y accesible."
+      "applies_if_space_in": ["machinery_category_A", "accommodation", "munition_store"],
+      "forbid_joints": [
+        "slip_on.machine_grooved",
+        "slip_on.grip",
+        "slip_on.slip"
+      ],
+      "advisory": "Slip-on no aceptados en Máquinas Cat. A, Acomodación o Pañoles de Munición."
     },
     {
       "note_ids": [1],
       "refs": ["Note 1"],
       "applies_if_space_in": ["machinery_category_A"],
       "require_fire_resistant_type": true,
-      "advisory": "En el ‘bilge main’ de Cat. A, material del acople: acero/CuNi o equivalente."
+      "advisory": "En Cat. A las juntas deben ser de tipo resistente al fuego. (Adicional: bilge main en Cat. A debe ser acero/CuNi o equivalente)."
     },
     {
       "note_ids": [3],
       "refs": ["Note 3"],
-      "applies_if_space_in": ["open_deck_low_fire_risk","weather_deck"],
-      "require_fire_resistant_type": false
+      "applies_if_space_in": ["open_deck_low_fire_risk"],
+      "advisory": "En cubierta abierta con poco o nulo riesgo de fuego (SOLAS II-2/9.2.3.3.2.2(10)) puede exceptuarse el requisito de tipo resistente al fuego, salvo líneas de fuel oil."
     },
     {
       "note_ids": [6],
       "refs": ["Note 6"],
-      "applies_if_space_in": ["accommodation","machinery_other","machinery_category_A","dry_space"],
-      "advisory": "Deck drains (internos) solo por encima del límite de integridad estanca."
+      "applies_if_space_in": ["above_limit_watertight_integrity_only"],
+      "advisory": "Sistemas de desagüe internos sólo por encima del límite de estanqueidad."
     },
     {
-      "note_ids": [7],
-      "refs": ["Note 7"],
-      "applies_if_space_in": ["weather_deck","protected_space"],
-      "advisory": "Requisitos específicos para HVAC trunking y gas turbine intakes/uptakes según secciones aplicables."
+      "note_ids": [9],
+      "refs": ["5.10.9"],
+      "applies_if_space_in": ["cargo_hold", "tank_other_medium", "not_easily_accessible"],
+      "forbid_joints": [
+        "slip_on.machine_grooved",
+        "slip_on.grip",
+        "slip_on.slip"
+      ],
+      "advisory": "En bodegas, tanques u otros espacios no fácilmente accesibles no se usan slip-on. Dentro de tanques sólo si el fluido es el mismo del tanque."
+    },
+    {
+      "note_ids": [10],
+      "refs": ["5.10.10"],
+      "applies_if_space_in": ["weather_deck"],
+      "advisory": "Slip-type como medio principal de unión no está permitido, salvo para compensar deformación axial; ‘restrained slip-on’ permitido en condiciones específicas."
     }
   ],
-  "global_rules": [
-    {
-      "note_ids": [4],
-      "refs": ["Note 4"],
-      "applies_if_system_in": ["aircraft_vehicle_fuel_oil_lt60","aircraft_vehicle_fuel_oil_gt60"],
-      "force_fire_resistant_type": true
+  "notes_text": {
+    "1": {
+      "es": "Las juntas mecánicas deben ser de tipo resistente al fuego cuando se instalen en espacios de maquinaria de Categoría A. Las uniones mecánicas en la ‘bilge main’ en Cat. A deben ser de acero, CuNi o material equivalente.",
+      "en": "Mechanical joints are to be of an approved fire-resistant type when fitted in machinery spaces of Category A. Mechanical couplings fitted on the bilge main in Category A machinery spaces are to be of steel, CuNi or equivalent material."
     },
-    {
-      "note_ids": [3],
-      "refs": ["Note 3"],
-      "applies_if_system_in": ["ships_machinery_fuel_oil"],
-      "force_fire_resistant_type": true
+    "2": {
+      "es": "Las juntas tipo slip-on no se aceptan dentro de espacios de maquinaria de Categoría A, pañoles de munición ni espacios de alojamiento. Se aceptan en otros espacios de maquinaria/servicio si están en posiciones visibles y accesibles.",
+      "en": "Slip-on joints are not accepted inside machinery spaces of Category A, munition stores, or accommodation spaces. Slip-on joints are accepted in other machinery and service spaces provided the joints are in easily visible and accessible positions."
     },
-    {
-      "note_ids": [5],
-      "refs": ["5.10.10","5.10.11"],
-      "applies_if_system_in": ["steam_general"],
-      "advisory": "Slip type no como medio principal salvo compensación axial. ‘Restrained’ slip-on permitido en weather deck ≤10 bar."
+    "3": {
+      "es": "Las juntas mecánicas deben ser de tipo resistente al fuego, excepto cuando se instalen en cubiertas abiertas con poco o nulo riesgo de fuego según SOLAS II-2/9.2.3.3.2.2(10).",
+      "en": "Mechanical joints are to be of an approved fire-resistant type, except when fitted on open decks having little or no fire risk as defined in SOLAS Ch II-2 Reg. 9.2.3.3.2.2(10)."
+    },
+    "4": {
+      "es": "Juntas de tipo resistente al fuego (aplicable como requisito adicional según la fila del sistema).",
+      "en": "Mechanical joints are to be of an approved fire-resistant type (as required by the service row)."
+    },
+    "5": {
+      "es": "Ver 5.10.10 (otras acotaciones para vapor/expansión axial).",
+      "en": "See 5.10.10 (further steam/axial expansion provisions)."
+    },
+    "6": {
+      "es": "Sólo por encima del límite de estanqueidad.",
+      "en": "Only above the limit of watertight integrity."
+    },
+    "7": {
+      "es": "Los requisitos para conductos HVAC o tomas/descargas de turbinas de gas se abordan en sus secciones respectivas.",
+      "en": "Requirements for HVAC trunking or gas turbine uptakes and intakes are addressed in the relevant Sections."
+    },
+    "9": {
+      "es": "§5.10.9: Generalmente los slip-on no se usan en bodegas, tanques y espacios no fácilmente accesibles. Dentro de tanques sólo si el medio conducido es el mismo que el contenido del tanque.",
+      "en": "§5.10.9: Generally, slip-on joints are not to be used in cargo holds, tanks, and other spaces not easily accessible. Inside tanks may be accepted only where the medium conveyed is the same as that in the tanks."
+    },
+    "10": {
+      "es": "§5.10.10: El uso de slip-type como medio principal de unión no está permitido salvo para compensar deformación axial (p.ej., ‘restrained slip-on’ en condiciones específicas).",
+      "en": "§5.10.10: Usage of slip type slip-on joints as the main means of pipe connection is not permitted except where compensation of axial pipe deformation is necessary (e.g., restrained slip-on in specific conditions)."
     }
-  ]
+  }
 }

--- a/lr_naval.table_class.json
+++ b/lr_naval.table_class.json
@@ -1,5 +1,17 @@
 {
+  "pipe_union": {
+    "I":   { "allowed": true,  "od_mm_max": 60.3 },
+    "II":  { "allowed": true,  "od_mm_max": 60.3 },
+    "III": { "allowed": true }
+  },
+
   "pipe_unions.welded_brazed": {
+    "I":   { "allowed": true,  "od_mm_max": 60.3 },
+    "II":  { "allowed": true,  "od_mm_max": 60.3 },
+    "III": { "allowed": true }
+  },
+
+  "compression": {
     "I":   { "allowed": true,  "od_mm_max": 60.3 },
     "II":  { "allowed": true,  "od_mm_max": 60.3 },
     "III": { "allowed": true }

--- a/lr_naval.table_service.json
+++ b/lr_naval.table_service.json
@@ -1,41 +1,30 @@
 [
-  { "system_group":"Flammable fluids (flash point < 60°C)", "system":"aircraft_vehicle_fuel_oil_lt60", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":"30min_dry", "notes":[2,4] },
-  { "system_group":"Flammable fluids (flash point < 60°C)", "system":"vent_lines_lt60", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":"30min_dry", "notes":[2,3] },
-
-  { "system_group":"Flammable fluids (flash point > 60°C)", "system":"aircraft_vehicle_fuel_oil_gt60", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":"30min_dry", "notes":[2,4] },
-  { "system_group":"Flammable fluids (flash point > 60°C)", "system":"ships_machinery_fuel_oil", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":"30min_wet", "notes":[2,3] },
-  { "system_group":"Flammable fluids (flash point > 60°C)", "system":"lubricating_oil_lines", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":null, "notes":[2,3] },
-  { "system_group":"Flammable fluids (flash point > 60°C)", "system":"hydraulic_oil_lines", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":null, "notes":[2,3] },
-
-  { "system_group":"Sea water", "system":"bilge_lines", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry","wet"], "type_fire_test":"8dry_22wet", "notes":[1] },
-  { "system_group":"Sea water", "system":"hp_sea_water_spray_not_perm", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry","wet"], "type_fire_test":"8dry_22wet", "notes":[] },
-  { "system_group":"Sea water", "system":"fire_ext_perm_filled", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":"30min_wet", "notes":[3] },
-  { "system_group":"Sea water", "system":"fire_ext_non_perm_filled", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry","wet"], "type_fire_test":"8dry_22wet", "notes":[3], "extra":"For foam systems FSS Code to be observed" },
-  { "system_group":"Sea water", "system":"ballast_system", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":"8dry_22wet", "notes":[1] },
-  { "system_group":"Sea water", "system":"sea_cooling_water", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":"8dry_22wet", "notes":[1] },
-  { "system_group":"Sea water", "system":"tank_cleaning_services", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":"not_required", "notes":[] },
-  { "system_group":"Sea water", "system":"sea_non_essential", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry","wet","dry_wet"], "type_fire_test":"not_required", "notes":[] },
-
-  { "system_group":"Fresh water", "system":"fresh_cooling_water", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":"not_required", "notes":[1], "extra":"Except chilled water: 30 min wet" },
-  { "system_group":"Fresh water", "system":"chilled_water_system", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":"30min_wet", "notes":[1] },
-  { "system_group":"Fresh water", "system":"condensate_return", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":null, "notes":[1] },
-  { "system_group":"Fresh water", "system":"made_demin_water_system", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":null, "notes":[] },
-  { "system_group":"Fresh water", "system":"ancillary_system", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":null, "notes":[] },
-
-  { "system_group":"Sanitary/drains/scuppers", "system":"deck_drains_internal", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":"not_required", "notes":[6] },
-  { "system_group":"Sanitary/drains/scuppers", "system":"sanitary_drains", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":null, "notes":[] },
-  { "system_group":"Sanitary/drains/scuppers", "system":"scuppers_overboard", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press"], "fire_condition":["dry"], "type_fire_test":null, "notes":[] },
-
-  { "system_group":"Sounding/vent", "system":"sounding_water_tanks_dry_spaces", "allowed_joints":["pipe_unions.welded_brazed"], "fire_condition":["dry","wet"], "type_fire_test":"not_required", "notes":[] },
-  { "system_group":"Sounding/vent", "system":"intakes_uptakes", "allowed_joints":["compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":null, "notes":[7] },
-  { "system_group":"Sounding/vent", "system":"hvac_trunking", "allowed_joints":[], "fire_condition":["dry"], "type_fire_test":null, "notes":[7] },
-
-  { "system_group":"Miscellaneous", "system":"hp_air_system", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":"30min_dry", "notes":[1] },
-  { "system_group":"Miscellaneous", "system":"mp_air_system", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":"30min_dry", "notes":[1] },
-  { "system_group":"Miscellaneous", "system":"lp_air_system", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":"not_required", "notes":[1] },
-  { "system_group":"Miscellaneous", "system":"service_air_non_essential", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["dry"], "type_fire_test":null, "notes":[] },
-  { "system_group":"Miscellaneous", "system":"brine", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press","slip_on.machine_grooved","slip_on.grip","slip_on.slip"], "fire_condition":["wet"], "type_fire_test":null, "notes":[] },
-  { "system_group":"Miscellaneous", "system":"co2_system", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press"], "fire_condition":["dry"], "type_fire_test":"30min_dry", "notes":[1] },
-  { "system_group":"Miscellaneous", "system":"nitrogen_system", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press"], "fire_condition":["dry"], "type_fire_test":"30min_dry", "notes":[] },
-  { "system_group":"Miscellaneous", "system":"steam_general", "allowed_joints":["pipe_unions.welded_brazed","compression.swage","compression.bite","compression.typical_compression","compression.flared","compression.press"], "fire_condition":["dry"], "type_fire_test":"not_required", "notes":[5], "extra":"Slip type no como medio principal salvo compensar dilatación axial (5.10.10). Restrained en weather deck ≤10 bar (5.10.11)." }
+  {
+    "key": "flammables_lt60.cargo_oil_lines",
+    "label_es": "Fluidos inflamables (f.p. < 60°C) – Cargo oil lines",
+    "allowed_joints": ["pipe_union", "compression", "slip_on.machine_grooved", "slip_on.grip", "slip_on.slip"],
+    "type_fire_test": "30min_dry",
+    "notes": []
+  },
+  {
+    "key": "inert_gas.main_lines",
+    "label_es": "Gas inerte – Líneas principales",
+    "allowed_joints": ["pipe_union", "compression", "slip_on.machine_grooved", "slip_on.grip", "slip_on.slip"],
+    "type_fire_test": "30min_dry",
+    "notes": []
+  },
+  {
+    "key": "ships_machinery.fuel_oil_lines",
+    "label_es": "Líneas de fuel oil de la maquinaria del buque",
+    "allowed_joints": ["pipe_union", "compression", "slip_on.machine_grooved", "slip_on.grip", "slip_on.slip"],
+    "type_fire_test": "30min_wet",
+    "notes": [2, 3]
+  },
+  {
+    "key": "sanitary.deck_drains_internal",
+    "label_es": "Drenajes de cubierta (internos)",
+    "allowed_joints": ["pipe_union", "compression", "slip_on.machine_grooved"],
+    "type_fire_test": "none",
+    "notes": [6]
+  }
 ]

--- a/lr_naval.tests.json
+++ b/lr_naval.tests.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "Cargo oil <60°C en Cat. A (Naval)",
+    "input": { "systemKey":"flammables_lt60.cargo_oil_lines", "spaceKey":"machinery_category_A", "klass":"III", "od_mm":60 },
+    "expect": {
+      "slip_on.machine_grooved":"NO",
+      "slip_on.grip":"NO",
+      "slip_on.slip":"NO",
+      "notes":[1,2],
+      "fire_test":"30min_dry"
+    }
+  },
+  {
+    "name": "Fuel oil (maquinaria) en Cat. A (Naval)",
+    "input": { "systemKey":"ships_machinery.fuel_oil_lines", "spaceKey":"machinery_category_A", "klass":"II", "od_mm":50 },
+    "expect": {
+      "slip_on.machine_grooved":"NO",
+      "slip_on.grip":"NO",
+      "slip_on.slip":"NO",
+      "notes":[1,2,3],
+      "fire_test":"30min_wet"
+    }
+  },
+  {
+    "name": "Slip-on en tanque con MISMO medio (Naval, §5.10.9 excepción)",
+    "input": { "systemKey":"flammables_lt60.cargo_oil_lines", "spaceKey":"tank_same_medium", "klass":"III", "od_mm":60, "inside_tank_medium_same": true },
+    "expect": {
+      "slip_on.machine_grooved":"SI",
+      "slip_on.grip":"SI",
+      "slip_on.slip":"SI",
+      "notes":[],
+      "fire_test":"30min_dry"
+    }
+  },
+  {
+    "name": "Slip-on en tanque con OTRO medio (Naval, §5.10.9 prohibido)",
+    "input": { "systemKey":"flammables_lt60.cargo_oil_lines", "spaceKey":"tank_other_medium", "klass":"III", "od_mm":60, "inside_tank_medium_same": false },
+    "expect": {
+      "slip_on.machine_grooved":"NO",
+      "slip_on.grip":"NO",
+      "slip_on.slip":"NO",
+      "notes":[9],
+      "fire_test":"30min_dry"
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/rules-lr-naval.js
+++ b/rules-lr-naval.js
@@ -1,0 +1,178 @@
+// rules-lr-naval.js
+
+const SERVICE = await (await fetch('./lr_naval.table_service.json')).json();
+const CLASS   = await (await fetch('./lr_naval.table_class.json')).json();
+const NOTES   = await (await fetch('./lr_naval.notes.json')).json();
+
+/**
+ * params:
+ *  - systemKey: clave de fila 1.5.3
+ *  - spaceKey: clave de espacio (ver lista)
+ *  - klass: 'I' | 'II' | 'III'
+ *  - od_mm: número
+ *  - inside_tank_medium_same?: boolean (opcional; por defecto false)
+ */
+export function evaluateLRNaval({ systemKey, spaceKey, klass, od_mm, inside_tank_medium_same = false }) {
+  const row = findRow(systemKey);
+  if (!row) return { cards: [], debug: ["Row not found"] };
+
+  let joints = new Set(row.allowed_joints);
+  const appliedNotes = new Set();
+  const flags = { fireTest: null, fireResistantType: false };
+  const debug = [];
+
+  // 1) Clase/OD (Tabla 1.5.4)
+  joints = new Set([...joints].filter(j => {
+    const rule = CLASS[j]?.[klass];
+    if (!rule) { debug.push(`No class rule for ${j}/${klass}`); return false; }
+    if (rule.allowed === false) { debug.push(`Class deny ${j}`); return false; }
+    if (typeof rule.od_mm_max === 'number' && od_mm > rule.od_mm_max) {
+      debug.push(`OD limit ${j} ${od_mm} > ${rule.od_mm_max}`);
+      return false;
+    }
+    return true;
+  }));
+
+  // 2) Reglas por espacio (prohibiciones / flags)
+  for (const sr of NOTES.space_rules) {
+    if (!sr.applies_if_space_in?.includes(spaceKey)) continue;
+
+    // §5.10.9 excepción: tanque con mismo medio
+    if (sr.note_ids?.includes(9) && spaceKey.startsWith('tank') && inside_tank_medium_same) {
+      debug.push('5.10.9: mismo medio en tanque -> no se prohíbe slip-on');
+    } else {
+      if (sr.forbid_joints) {
+        for (const j of sr.forbid_joints) {
+          if (joints.delete(j)) debug.push(`Forbidden by N${sr.note_ids[0]}: ${j}`);
+        }
+      }
+    }
+
+    if (sr.require_fire_resistant_type) flags.fireResistantType = true;
+    if (sr.require_installation_fire_test) {
+      if (!flags.fireTest && row.type_fire_test && row.type_fire_test !== 'none') {
+        flags.fireTest = row.type_fire_test;
+      }
+    }
+    sr.note_ids?.forEach(n => appliedNotes.add(n));
+  }
+
+  // 3) Notas declaradas en la fila (1.5.3)
+  for (const n of (row.notes || [])) {
+    switch (n) {
+      case 1:
+        if (spaceKey === 'machinery_category_A') {
+          flags.fireResistantType = true;
+          appliedNotes.add(1);
+        }
+        break;
+      case 2:
+        if (['machinery_category_A','accommodation','munition_store'].includes(spaceKey)) {
+          ['slip_on.machine_grooved','slip_on.grip','slip_on.slip'].forEach(j => joints.delete(j));
+          appliedNotes.add(2);
+        }
+        break;
+      case 3:
+        appliedNotes.add(3);
+        if (spaceKey !== 'open_deck_low_fire_risk') {
+          flags.fireResistantType = true;
+        }
+        break;
+      case 4:
+        appliedNotes.add(4);
+        flags.fireResistantType = true;
+        break;
+      case 5:
+        appliedNotes.add(5);
+        break;
+      case 6:
+        if (spaceKey === 'above_limit_watertight_integrity_only') appliedNotes.add(6);
+        break;
+      case 7:
+        appliedNotes.add(7);
+        break;
+      default:
+        break;
+    }
+  }
+
+  // 4) Ensayo (sin equivalencias en Naval)
+  if (!flags.fireTest && row.type_fire_test && row.type_fire_test !== 'none') {
+    flags.fireTest = row.type_fire_test;
+  }
+
+  // 5) Tarjetas
+  const cards = buildCards([...joints], { row, flags, appliedNotes: [...appliedNotes] });
+  return { cards, debug };
+}
+
+function findRow(systemKey){
+  if (Array.isArray(SERVICE)) return SERVICE.find(r => r.key === systemKey);
+  return SERVICE[systemKey];
+}
+
+function buildCards(joints, ctx){
+  const all = [
+    { key: 'pipe_union', label: 'Unión roscada/soldada' },
+    { key: 'compression', label: 'Acople de compresión' },
+    { key: 'slip_on.machine_grooved', label: 'Ranurado mecánico' },
+    { key: 'slip_on.grip', label: 'Grip (ranurado)' },
+    { key: 'slip_on.slip', label: 'Slip (tipo slip-on)' }
+  ];
+  return all.map(item => {
+    const allowed = joints.includes ? joints.includes(item.key) : joints.has(item.key);
+    let reason = allowed ? null : reasonFor(item.key, ctx);
+    return {
+      joint_key: item.key,
+      title: item.label,
+      status: allowed ? 'PERMITIDO' : 'NO PERMITIDO',
+      reason,
+      fire_test: allowed ? formatFireTest(ctx.flags) : null,
+      fire_resistant_tag: ctx.flags.fireResistantType ? 'Tipo resistente al fuego requerido' : null,
+      notes: ctx.appliedNotes.sort((a,b)=>a-b)
+    };
+  });
+}
+
+function reasonFor(jointKey, { appliedNotes }){
+  const isSlip = jointKey.startsWith('slip_on');
+  if (isSlip && appliedNotes.includes(2)) return 'Prohibido por Nota 2';
+  if (isSlip && appliedNotes.includes(9)) return 'Prohibido por §5.10.9';
+  return 'Restringido por clase/OD (1.5.4) o nota aplicable';
+}
+
+function formatFireTest(flags){
+  if (!flags.fireTest) return null;
+  const map = {
+    '30min_dry': 'Ensayo (fila): 30 min seco',
+    '8dry_22wet': 'Ensayo (fila): 8 min seco + 22 min húmedo',
+    '30min_wet': 'Ensayo (fila): 30 min húmedo'
+  };
+  return map[flags.fireTest] || null;
+}
+
+export function getNavalNoteText(noteId, lang='es'){
+  const n = NOTES.notes_text?.[String(noteId)];
+  if (!n) return { es: '', en: '' };
+  return { es: n.es, en: n.en };
+}
+
+export async function runLRNavalTests() {
+  const tests = await (await fetch('./lr_naval.tests.json')).json();
+  const out = [];
+  for (const t of tests) {
+    const { cards } = evaluateLRNaval(t.input);
+    const map = Object.fromEntries(cards.map(c => [c.joint_key, c.status==='PERMITIDO' ? 'SI' : 'NO']));
+    const notes = [...new Set(cards.flatMap(c => c.notes))].sort((a,b)=>a-b);
+    const fire = cards.find(c => c.fire_test)?.fire_test || null;
+    out.push({ name:t.name, pass:
+      map['slip_on.machine_grooved']===t.expect['slip_on.machine_grooved'] &&
+      map['slip_on.grip']===t.expect['slip_on.grip'] &&
+      map['slip_on.slip']===t.expect['slip_on.slip'] &&
+      JSON.stringify(notes)===JSON.stringify(t.expect.notes) &&
+      (!!fire) === (!!t.expect.fire_test)
+    , got:{ map, notes, fire }, expect:t.expect });
+  }
+  console.table(out.map(x=>({name:x.name, pass:x.pass})));
+  return out;
+}


### PR DESCRIPTION
## Summary
- replace LR Naval notes and service data with the new rule set and space restrictions
- add the LR Naval evaluator module, JSON fixtures, and extend the UI with a dedicated Naval form and tank medium toggle
- enable ESM execution for local tests and provide a focused Naval test suite

## Testing
- `node -e "globalThis.fetch = async (resource) => { const { readFile } = await import('node:fs/promises'); const { resolve } = await import('node:path'); const data = await readFile(resolve(resource), 'utf8'); return { async json() { return JSON.parse(data); } }; }; import('./rules-lr-naval.js').then(m => m.runLRNavalTests());"`


------
https://chatgpt.com/codex/tasks/task_e_68e48bb70cd0832183bba2957bcaf5af