### PR TITLE
Sync LR Naval data in static evaluator

### DIFF
--- a/juntas.html
+++ b/juntas.html
@@ -269,11 +269,11 @@ function buildNaval(){
   });
   const SYSTEM_GROUPS = [
     { key:"flamm_lt60", label:"Fluidos inflamables (fp < 60°C)", systems:[
-      { key:"veh_aircraft_fuel_lt60", label:"Líneas de combustible (vehículos/aeronaves)", allow:allowAll(), notes:["n2","n4"], fire:"30 min dry" },
+      { key:"veh_aircraft_fuel_lt60", label:"Líneas de combustible (vehículos / aeronaves)", allow:allowAll(), notes:["n2","n4"], fire:"30 min dry" },
       { key:"vent_lt60", label:"Líneas de venteo", allow:allowAll(), notes:["n3"], fire:"30 min dry" }
     ]},
     { key:"flamm_gt60", label:"Fluidos inflamables (fp > 60°C)", systems:[
-      { key:"veh_aircraft_fuel_gt60", label:"Líneas de combustible (vehículos/aeronaves)", allow:allowAll(), notes:["n2","n4"], fire:"30 min dry" },
+      { key:"veh_aircraft_fuel_gt60", label:"Líneas de combustible (vehículos / aeronaves)", allow:allowAll(), notes:["n2","n4"], fire:"30 min dry" },
       { key:"machinery_fuel", label:"Líneas de combustible – maquinaria de a bordo", allow:allowAll(), notes:["n2","n3"], fire:"30 min wet" },
       { key:"lube_oil", label:"Líneas de aceite lubricante", allow:allowAll(), notes:["n2","n3"], fire:"30 min wet" },
       { key:"hydraulic_oil", label:"Aceite hidráulico", allow:allowAll(), notes:["n2","n3"], fire:"30 min wet" }
@@ -284,19 +284,25 @@ function buildNaval(){
       { key:"fire_perm", label:"Contra-incendios (llenado permanente)", allow:allowAll(), notes:["n3"], fire:"30 min wet" },
       { key:"fire_nonperm", label:"Contra-incendios (no permanente) / espuma / drencher", allow:allowAll(), notes:["n3"], fire:"8 dry + 22 wet" },
       { key:"ballast", label:"Lastre", allow:allowAll(), notes:["n1"], fire:"8 dry + 22 wet" },
-      { key:"cooling_sw", label:"Refrigeración – agua de mar", allow:allowAll(), notes:["n1"], fire:"8 dry + 22 wet" }
+      { key:"cooling_sw", label:"Refrigeración – agua de mar", allow:allowAll(), notes:["n1"], fire:"8 dry + 22 wet" },
+      { key:"tank_cleaning_services", label:"Servicios de limpieza de tanques", allow:allowAll(), notes:[], fire:"Fire endurance test not required" },
+      { key:"non_essential_systems", label:"Sistemas no esenciales", allow:allowAll(), notes:[], fire:"Fire endurance test not required" }
     ]},
     { key:"freshwater", label:"Agua dulce", systems:[
       { key:"cooling_fw", label:"Refrigeración – agua dulce", allow:allowAll(), notes:["n1"], fire:"(no aplica)" },
       { key:"chilled", label:"Agua helada (chilled)", allow:allowAll(), notes:["n1"], fire:"30 min wet" },
       { key:"cond_return", label:"Retorno de condensado", allow:allowAll(), notes:["n1"], fire:"(dry)" },
-      { key:"demin", label:"Agua tratada/desmineralizada", allow:allowAll(), notes:[], fire:"(wet)" },
+      { key:"demin", label:"Agua tratada / desmineralizada", allow:allowAll(), notes:[], fire:"(wet)" },
       { key:"ancillary", label:"Sistemas auxiliares (FW)", allow:allowAll(), notes:[], fire:"(dry)" }
     ]},
     { key:"sanitary", label:"Sanitarios / drenajes / escuppers", systems:[
       { key:"deck_drains_internal", label:"Drenajes de cubierta (internos)", allow:allowAll(), notes:["n6"], fire:"(no aplica)" },
       { key:"sanitary_drains", label:"Drenajes sanitarios", allow:allowAll(), notes:[], fire:"(dry)" },
-      { key:"scuppers_overboard", label:"Scuppers y descarga (sobre costado)", allow:{...allowAll(), slip_type:false, slip_grip:false, slip_mgrooved:false}, notes:[], fire:"(dry)" }
+      { key:"scuppers_overboard", label:"Scuppers y descarga (sobre costado)", allow:{...allowAll(), slip_mgrooved:false, slip_grip:false, slip_type:false}, notes:[], fire:"(dry)" }
+    ]},
+    { key:"sounding_vent", label:"Sondajes / venteos", systems:[
+      { key:"water_tanks_dry_spaces", label:"Tanques de agua / espacios secos", allow:allowAll(), notes:[], fire:"Fire endurance test not required" },
+      { key:"oil_tanks_fp_gt60", label:"Tanques de aceite (fp > 60°C)", allow:allowAll(), notes:["n2","n3"], fire:"Fire endurance test not required" }
     ]},
     { key:"misc", label:"Misceláneos / gases / vapor", systems:[
       { key:"air_hp", label:"Aire alta presión (HP)", allow:allowAll(), notes:["n1"], fire:"30 min dry" },
@@ -304,8 +310,8 @@ function buildNaval(){
       { key:"air_lp", label:"Aire baja presión (LP)", allow:allowAll(), notes:["n1"], fire:"(no aplica)" },
       { key:"service_air", label:"Aire de servicio (no esencial)", allow:allowAll(), notes:[], fire:"(no aplica)" },
       { key:"brine", label:"Salmuera (brine)", allow:allowAll(), notes:[], fire:"(wet)" },
-      { key:"co2", label:"CO₂ (fuera del espacio protegido)", allow:{...allowAll(), slip_type:false, slip_grip:false, slip_mgrooved:false}, notes:["n1"], fire:"30 min dry" },
-      { key:"nitrogen", label:"Nitrógeno", allow:{...allowAll(), slip_type:false, slip_grip:false, slip_mgrooved:false}, notes:[], fire:"30 min dry" },
+      { key:"co2_outside", label:"CO₂ (fuera del espacio protegido)", allow:{...allowAll(), slip_mgrooved:false, slip_grip:false, slip_type:false}, notes:["n1"], fire:"30 min dry" },
+      { key:"co2_inside", label:"CO₂ (dentro del espacio protegido)", allow:{...allowAll(), slip_mgrooved:false, slip_grip:false, slip_type:false}, notes:[], fire:"(dry)" },
       { key:"steam", label:"Vapor", allow:{pipe_union_welded_brazed:true,comp_swage:true,comp_bite:true,comp_typical:true,comp_flared:true,comp_press:true,slip_mgrooved:false,slip_grip:false,slip_type:true}, notes:["n5"], fire:"(no aplica)" }
     ]}
   ];
@@ -563,23 +569,18 @@ const DATASETS = {
 
 // === Mapeo imagen por tipo de junta (usa tus archivos en assets/joints) ===
 const JOINT_IMAGES = {
-  pipe_union_welded_brazed: ['welded_brazed.png','pipe_welded_brazed.jpg'],
-  comp_swage: ['compression_swage.png','compression_swage.jpg'],
-  comp_bite: ['compression_bite.png','compression_bite.jpg'],
-  comp_typical: ['compression_typical.png','compression_typical.jpg'],
-  comp_flared: ['compression_flared.png','compression_flared.jpg'],
-  comp_press: ['compression_press.png','compression_press.jpg'],
-  slip_mgrooved: ['slip_machine_grooved.png','slip_machine_grooved.jpg'],
-  slip_grip: ['slip_grip.png','slip_grip.jpg'],
-  slip_type: ['slip_slip.png','slip_slip.jpg']
+  pipe_union_welded_brazed: 'welded_brazed.png',
+  comp_swage: 'compression_swage.png',
+  comp_bite: 'compression_bite.png',
+  comp_typical: 'compression_typical.png',
+  comp_flared: 'compression_flared.png',
+  comp_press: 'compression_press.png',
+  slip_mgrooved: 'slip_machine_grooved.png',
+  slip_grip: 'slip_grip.png',
+  slip_type: 'slip_slip.png'
 };
 function jointImgPath(key){
-  const cands = JOINT_IMAGES[key] || [];
-  for(const f of cands){
-    // ruta final:
-    return 'assets/joints/'+f; // (simple: tomamos el primero)
-  }
-  return 'assets/joints/not-found.jpg';
+  return 'assets/joints/' + (JOINT_IMAGES[key] || 'not-found.jpg');
 }
 
 /* =========================
@@ -977,10 +978,10 @@ function renderResults(ds, items){
   const order = Array.from(new Set(ds.JOINT_TYPES.map(j=>j.group)));
   const byGroup = {};
   for(const it of items){
-    const jt = ds.JOINT_TYPES.find(x=>x.key===it.jt);
-    if(!jt) continue;
-    const g = jt.group;
-    (byGroup[g] ||= []).push({jt, ...it});
+    const joint = ds.JOINT_TYPES.find(x=>x.key===it.jt);
+    if(!joint) continue;
+    const g = joint.group;
+    (byGroup[g] ||= []).push({joint, ...it});
   }
   results.innerHTML = order.map(gr=>{
     const arr = byGroup[gr]||[];
@@ -996,10 +997,8 @@ function renderResults(ds, items){
   }).join('');
   $$('.js-view').forEach(btn=>{
     btn.addEventListener('click', ()=>{
-      const key = btn.getAttribute('data-key');
-      const src = jointImgPath(key);
-      $('#imgModalSrc').src = src;
-      $('#imgModal').classList.add('open');
+      const key = btn.getAttribute('data-key') || '';
+      window.open(jointImgPath(key), '_blank');
     });
   });
 }
@@ -1011,7 +1010,9 @@ function groupES(gr){
   return gr;
 }
 
-function cardHTML(ds, {jt,status,reasons}){
+function cardHTML(ds, {joint,jt,status,reasons}){
+  const jtObj = joint || ds.JOINT_TYPES.find(x=>x.key===jt);
+  if(!jtObj) return '';
   const badge = status==='ok' ? '<span class="badge b-ok">Permitido</span>'
               : status==='warn' ? '<span class="badge b-warn">Permitido con condiciones</span>'
               : '<span class="badge b-bad">Prohibido</span>';
@@ -1020,11 +1021,11 @@ function cardHTML(ds, {jt,status,reasons}){
   return `
     <div class="card">
       <div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
-        <div style="font-weight:600">${jt.label}</div>
+        <div style="font-weight:600">${jtObj.label}</div>
         ${badge}
       </div>
       ${rs}
-      <div class="mt-2"><span class="link js-view" data-key="${jt.key}">${figLabel}</span></div>
+      <div class="mt-2"><button type="button" class="link js-view" data-key="${jtObj.key}" style="background:none;border:0;padding:0;">${figLabel}</button></div>
     </div>`;
 }
 

--- a/src/components/Evaluator.tsx
+++ b/src/components/Evaluator.tsx
@@ -2,6 +2,20 @@ import React, { useEffect, useMemo, useState } from 'react';
 import type { Dataset, ClassName, System, JointKey } from '../core/types';
 import { evaluate, type EvalItem } from '../core/evaluator';
 
+const JOINT_IMAGES: Record<string, string> = {
+  pipe_union_welded_brazed: 'welded_brazed.png',
+  comp_swage: 'compression_swage.png',
+  comp_bite: 'compression_bite.png',
+  comp_typical: 'compression_typical.png',
+  comp_flared: 'compression_flared.png',
+  comp_press: 'compression_press.png',
+  slip_mgrooved: 'slip_machine_grooved.png',
+  slip_grip: 'slip_grip.png',
+  slip_type: 'slip_slip.png',
+};
+
+const jointImgPath = (k: string) => `assets/joints/${JOINT_IMAGES[k] ?? 'not-found.jpg'}`;
+
 const STATUS_LABEL: Record<EvalItem['status'], string> = {
   ok: 'Permitido',
   warn: 'Condicional',
@@ -208,6 +222,15 @@ export default function Evaluator({ dataset }: Props) {
               ) : (
                 <p className="muted">Sin observaciones adicionales.</p>
               )}
+              <div>
+                <button
+                  type="button"
+                  className="text-xs underline"
+                  onClick={() => window.open(jointImgPath(item.jt), '_blank')}
+                >
+                  {dataset.id === 'ships' ? 'Ver figura 12.2.4/12.2.5' : 'Ver figura 1.5.4/1.5.5'}
+                </button>
+              </div>
             </article>
           ))}
         </div>

--- a/src/data/lr-naval.ts
+++ b/src/data/lr-naval.ts
@@ -74,6 +74,10 @@ function allowFrom(keys: string[]): Record<JointKey, boolean> {
   return allow;
 }
 
+const allTrue = (): Record<JointKey, boolean> => (
+  Object.fromEntries(JOINT_KEYS.map(k => [k, true])) as Record<JointKey, boolean>
+);
+
 const CLASS_RULES = {
   pipe_union_welded_brazed: {
     I:   { allowed: true, odLE: 60.3 },
@@ -124,54 +128,278 @@ const CLASS_RULES = {
 
 const SYSTEM_GROUPS = [
   {
-    key:'flamm_lt60',
-    label:'Fluidos inflamables (fp < 60°C)',
-    systems:[
+    key: 'flamm_lt60',
+    label: 'Fluidos inflamables (fp < 60°C)',
+    systems: [
       {
-        key:'cargo_oil_lt60',
-        label:'Cargo oil lines (fp < 60°C)',
-        allow: allowFrom(['pipe_union','compression','slip_on.machine_grooved','slip_on.grip','slip_on.slip']),
-        notes:[],
-        fire:'30 min dry',
+        key: 'veh_aircraft_fuel_lt60',
+        label: 'Líneas de combustible (vehículos / aeronaves)',
+        allow: allTrue(),
+        notes: ['n2', 'n4'],
+        fire: '30 min dry',
+      },
+      {
+        key: 'vent_lt60',
+        label: 'Líneas de venteo',
+        allow: allTrue(),
+        notes: ['n3'],
+        fire: '30 min dry',
       },
     ],
   },
   {
-    key:'inert_gas',
-    label:'Gas inerte',
-    systems:[
+    key: 'flamm_gt60',
+    label: 'Fluidos inflamables (fp > 60°C)',
+    systems: [
       {
-        key:'inert_main_lines',
-        label:'Líneas principales',
-        allow: allowFrom(['pipe_union','compression','slip_on.machine_grooved','slip_on.grip','slip_on.slip']),
-        notes:[],
-        fire:'30 min dry',
+        key: 'veh_aircraft_fuel_gt60',
+        label: 'Líneas de combustible (vehículos / aeronaves)',
+        allow: allTrue(),
+        notes: ['n2', 'n4'],
+        fire: '30 min dry',
+      },
+      {
+        key: 'machinery_fuel',
+        label: 'Líneas de combustible – maquinaria de a bordo',
+        allow: allTrue(),
+        notes: ['n2', 'n3'],
+        fire: '30 min wet',
+      },
+      {
+        key: 'lube_oil',
+        label: 'Líneas de aceite lubricante',
+        allow: allTrue(),
+        notes: ['n2', 'n3'],
+        fire: '30 min wet',
+      },
+      {
+        key: 'hydraulic_oil',
+        label: 'Aceite hidráulico',
+        allow: allTrue(),
+        notes: ['n2', 'n3'],
+        fire: '30 min wet',
       },
     ],
   },
   {
-    key:'machinery',
-    label:'Maquinaria del buque',
-    systems:[
+    key: 'seawater',
+    label: 'Agua de mar',
+    systems: [
       {
-        key:'fuel_oil_lines',
-        label:'Fuel oil lines',
-        allow: allowFrom(['pipe_union','compression','slip_on.machine_grooved','slip_on.grip','slip_on.slip']),
-        notes:['n2','n3'],
-        fire:'30 min wet',
+        key: 'bilge',
+        label: 'Líneas de achique (bilge)',
+        allow: allTrue(),
+        notes: ['n1'],
+        fire: '8 dry + 22 wet',
+      },
+      {
+        key: 'hp_seawater',
+        label: 'Agua de mar HP / spray (no llenado permanente)',
+        allow: allTrue(),
+        notes: [],
+        fire: '8 dry + 22 wet',
+      },
+      {
+        key: 'fire_perm',
+        label: 'Contra-incendios (llenado permanente)',
+        allow: allTrue(),
+        notes: ['n3'],
+        fire: '30 min wet',
+      },
+      {
+        key: 'fire_nonperm',
+        label: 'Contra-incendios (no permanente) / espuma / drencher',
+        allow: allTrue(),
+        notes: ['n3'],
+        fire: '8 dry + 22 wet',
+      },
+      {
+        key: 'ballast',
+        label: 'Lastre',
+        allow: allTrue(),
+        notes: ['n1'],
+        fire: '8 dry + 22 wet',
+      },
+      {
+        key: 'cooling_sw',
+        label: 'Refrigeración – agua de mar',
+        allow: allTrue(),
+        notes: ['n1'],
+        fire: '8 dry + 22 wet',
+      },
+      {
+        key: 'tank_cleaning_services',
+        label: 'Servicios de limpieza de tanques',
+        allow: allTrue(),
+        notes: [],
+        fire: 'Fire endurance test not required',
+      },
+      {
+        key: 'non_essential_systems',
+        label: 'Sistemas no esenciales',
+        allow: allTrue(),
+        notes: [],
+        fire: 'Fire endurance test not required',
       },
     ],
   },
   {
-    key:'sanitary',
-    label:'Sanitarios / drenajes',
-    systems:[
+    key: 'freshwater',
+    label: 'Agua dulce',
+    systems: [
       {
-        key:'deck_drains_internal',
-        label:'Drenajes de cubierta (internos)',
-        allow: allowFrom(['pipe_union','compression','slip_on.machine_grooved']),
-        notes:['n6'],
-        fire:'No requerido',
+        key: 'cooling_fw',
+        label: 'Refrigeración – agua dulce',
+        allow: allTrue(),
+        notes: ['n1'],
+        fire: '(no aplica)',
+      },
+      {
+        key: 'chilled',
+        label: 'Agua helada (chilled)',
+        allow: allTrue(),
+        notes: ['n1'],
+        fire: '30 min wet',
+      },
+      {
+        key: 'cond_return',
+        label: 'Retorno de condensado',
+        allow: allTrue(),
+        notes: ['n1'],
+        fire: '(dry)',
+      },
+      {
+        key: 'demin',
+        label: 'Agua tratada / desmineralizada',
+        allow: allTrue(),
+        notes: [],
+        fire: '(wet)',
+      },
+      {
+        key: 'ancillary',
+        label: 'Sistemas auxiliares (FW)',
+        allow: allTrue(),
+        notes: [],
+        fire: '(dry)',
+      },
+    ],
+  },
+  {
+    key: 'sanitary',
+    label: 'Sanitarios / drenajes / escuppers',
+    systems: [
+      {
+        key: 'deck_drains_internal',
+        label: 'Drenajes de cubierta (internos)',
+        allow: allTrue(),
+        notes: ['n6'],
+        fire: '(no aplica)',
+      },
+      {
+        key: 'sanitary_drains',
+        label: 'Drenajes sanitarios',
+        allow: allTrue(),
+        notes: [],
+        fire: '(dry)',
+      },
+      {
+        key: 'scuppers_overboard',
+        label: 'Scuppers y descarga (sobre costado)',
+        allow: { ...allTrue(), slip_mgrooved: false, slip_grip: false, slip_type: false },
+        notes: [],
+        fire: '(dry)',
+      },
+    ],
+  },
+  {
+    key: 'sounding_vent',
+    label: 'Sondajes / venteos',
+    systems: [
+      {
+        key: 'water_tanks_dry_spaces',
+        label: 'Tanques de agua / espacios secos',
+        allow: allTrue(),
+        notes: [],
+        fire: 'Fire endurance test not required',
+      },
+      {
+        key: 'oil_tanks_fp_gt60',
+        label: 'Tanques de aceite (fp > 60°C)',
+        allow: allTrue(),
+        notes: ['n2', 'n3'],
+        fire: 'Fire endurance test not required',
+      },
+    ],
+  },
+  {
+    key: 'misc',
+    label: 'Misceláneos / gases / vapor',
+    systems: [
+      {
+        key: 'air_hp',
+        label: 'Aire alta presión (HP)',
+        allow: allTrue(),
+        notes: ['n1'],
+        fire: '30 min dry',
+      },
+      {
+        key: 'air_mp',
+        label: 'Aire media presión (MP)',
+        allow: allTrue(),
+        notes: ['n1'],
+        fire: '30 min dry',
+      },
+      {
+        key: 'air_lp',
+        label: 'Aire baja presión (LP)',
+        allow: allTrue(),
+        notes: ['n1'],
+        fire: '(no aplica)',
+      },
+      {
+        key: 'service_air',
+        label: 'Aire de servicio (no esencial)',
+        allow: allTrue(),
+        notes: [],
+        fire: '(no aplica)',
+      },
+      {
+        key: 'brine',
+        label: 'Salmuera (brine)',
+        allow: allTrue(),
+        notes: [],
+        fire: '(wet)',
+      },
+      {
+        key: 'co2_outside',
+        label: 'CO₂ (fuera del espacio protegido)',
+        allow: { ...allTrue(), slip_mgrooved: false, slip_grip: false, slip_type: false },
+        notes: ['n1'],
+        fire: '30 min dry',
+      },
+      {
+        key: 'co2_inside',
+        label: 'CO₂ (dentro del espacio protegido)',
+        allow: { ...allTrue(), slip_mgrooved: false, slip_grip: false, slip_type: false },
+        notes: [],
+        fire: '(dry)',
+      },
+      {
+        key: 'steam',
+        label: 'Vapor',
+        allow: {
+          pipe_union_welded_brazed: true,
+          comp_swage: true,
+          comp_bite: true,
+          comp_typical: true,
+          comp_flared: true,
+          comp_press: true,
+          slip_mgrooved: false,
+          slip_grip: false,
+          slip_type: true,
+        },
+        notes: ['n5'],
+        fire: '(no aplica)',
       },
     ],
   },


### PR DESCRIPTION
## Summary
- align the embedded LR Naval dataset in the static juntas.html page with the newly added seawater services and the sounding/vent table entries
- update the joint image helper and card rendering so the "Ver figura" button opens the mapped figure in a new tab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e65b7a116083219444ff07dde0134f