### PR TITLE
Add gas turbine and HVAC entries to LR Naval sounding systems

### DIFF
--- a/juntas.html
+++ b/juntas.html
@@ -302,7 +302,9 @@ function buildNaval(){
     ]},
     { key:"sounding_vent", label:"Sondajes / venteos", systems:[
       { key:"water_tanks_dry_spaces", label:"Tanques de agua / espacios secos", allow:allowAll(), notes:[], fire:"Fire endurance test not required" },
-      { key:"oil_tanks_fp_gt60", label:"Tanques de aceite (fp > 60°C)", allow:allowAll(), notes:["n2","n3"], fire:"Fire endurance test not required" }
+      { key:"oil_tanks_fp_gt60", label:"Tanques de aceite (fp > 60°C)", allow:allowAll(), notes:["n2","n3"], fire:"Fire endurance test not required" },
+      { key:"gas_turbine_intakes_uptakes", label:"Tomas y descargas de turbina de gas", allow:allowAll(), notes:["n7"], fire:"Fire endurance test not required" },
+      { key:"hvac_trunking", label:"Conductos HVAC", allow:allowAll(), notes:["n7"], fire:"Fire endurance test not required" }
     ]},
     { key:"misc", label:"Misceláneos / gases / vapor", systems:[
       { key:"air_hp", label:"Aire alta presión (HP)", allow:allowAll(), notes:["n1"], fire:"30 min dry" },

--- a/src/data/lr-naval.ts
+++ b/src/data/lr-naval.ts
@@ -329,6 +329,20 @@ const SYSTEM_GROUPS = [
         notes: ['n2', 'n3'],
         fire: 'Fire endurance test not required',
       },
+      {
+        key: 'gas_turbine_intakes_uptakes',
+        label: 'Tomas y descargas de turbina de gas',
+        allow: allTrue(),
+        notes: ['n7'],
+        fire: 'Fire endurance test not required',
+      },
+      {
+        key: 'hvac_trunking',
+        label: 'Conductos HVAC',
+        allow: allTrue(),
+        notes: ['n7'],
+        fire: 'Fire endurance test not required',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- add gas turbine intake/uptake and HVAC trunking rows to the LR Naval sounding and venting systems dataset, including Note 7 linkage
- sync the legacy HTML data source so the new options appear in the static evaluator

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e66994f90c83218c892dd70dbf0469