### PR TITLE
Add shared branding header and fix joint image paths

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -102,3 +102,42 @@ small,
     padding: 36px 18px 48px;
   }
 }
+
+/* Branding + navegación común */
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 12px 0 16px;
+}
+
+.page-header .left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.back-link {
+  color: #93c5fd;
+  font-size: 14px;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.brand-logo {
+  width: 120px;
+  height: auto;
+  border-radius: 12px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+}
+
+/* Contenedor para la portada */
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}

--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -35,57 +35,10 @@
     margin: 0 auto;
     padding: 48px 24px 64px;
   }
-  nav { margin-bottom: 28px; }
-  nav a {
-    color: var(--accent);
-    text-decoration: none;
-    font-weight: 600;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    transition: color 0.2s ease;
-  }
-  nav a:hover { color: #7dd3fc; }
   .relative { position: relative; }
   .mt-3 { margin-top: 0.75rem; }
   .text-slate-300 { color: rgba(203, 213, 225, 0.92); }
   .max-w-3xl { max-width: 48rem; }
-  .page-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 24px;
-    flex-wrap: wrap;
-    margin-bottom: 32px;
-  }
-  .page-header .header-copy { flex: 1 1 380px; min-width: 260px; }
-  .page-header .header-brand {
-    flex: 0 0 auto;
-    max-width: 200px;
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-end;
-    padding: 12px;
-    border-radius: 22px;
-    background: rgba(15, 23, 42, 0.5);
-    backdrop-filter: blur(10px);
-    box-shadow: 0 16px 40px rgba(8, 47, 73, 0.35);
-  }
-  .page-header .header-brand img {
-    max-width: 100%;
-    height: auto;
-    border-radius: 14px;
-  }
-  .header-actions {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    margin-top: 20px;
-  }
-  .header-cta {
-    font-size: 15px;
-    padding: 12px 20px;
-  }
   h1 {
     font-size: clamp(26px, 4vw, 38px);
     margin: 0 0 12px;
@@ -428,12 +381,14 @@
 </head>
 <body>
 <div class="wrap">
-  <nav><a href="index.html">← Volver al inicio</a></nav>
-  <section class="relative hero-pr max-w-6xl mx-auto px-6">
-    <div class="logo-badge" aria-hidden="true" role="presentation">
-      <img src="assets/joints/cotec.jpg" alt="COTECMAR">
+  <header class="page-header">
+    <div class="left">
+      <a href="index.html" class="back-link">← Volver al inicio</a>
+      <img src="assets/joints/cotec.jpg" alt="COTECMAR" class="brand-logo">
     </div>
-
+    <div></div>
+  </header>
+  <section class="relative hero-pr max-w-6xl mx-auto px-6">
     <h1 class="hero-title font-extrabold">
       Compatibilidad De Paso para Tuberías
     </h1>

--- a/index.html
+++ b/index.html
@@ -84,14 +84,11 @@
 <body>
   <main>
     <h1>Herramientas de compatibilidad LR</h1>
+    <div class="branding">
+      <img src="assets/joints/cotec.jpg" alt="COTECMAR" class="brand-logo">
+    </div>
     <p>Selecciona la herramienta que desees consultar. Ambas páginas funcionan con rutas relativas, por lo que se pueden abrir directamente desde GitHub Pages o de forma local sin configuración adicional.</p>
     <ul>
-      <li>
-        <a class="card" href="asesor-juntas.html">
-          <strong>Asesor de juntas</strong>
-          <span>Consulta la idoneidad de uniones para sistemas y espacios específicos.</span>
-        </a>
-      </li>
       <li>
         <a class="card" href="juntas.html">
           <strong>Evaluador de juntas LR</strong>
@@ -104,7 +101,6 @@
           <span>Explora combinaciones de materiales y obtén notas de compatibilidad.</span>
         </a>
       </li>
-      <li><a href="juntas_ships.html">Evaluador de juntas – LR Ships</a></li>
     </ul>
     <footer>© Lloyd's Register · Referencia interna de compatibilidad de tuberías.</footer>
   </main>

--- a/juntas.html
+++ b/juntas.html
@@ -51,6 +51,13 @@
 </head>
 <body>
   <div class="wrap">
+    <header class="page-header">
+      <div class="left">
+        <a href="index.html" class="back-link">← Volver al inicio</a>
+        <img src="assets/joints/cotec.jpg" alt="COTECMAR" class="brand-logo">
+      </div>
+      <div></div>
+    </header>
     <div class="h1">Evaluador de juntas – LR</div>
 
     <!-- Controles -->
@@ -571,15 +578,15 @@ const DATASETS = {
 
 // === Mapeo imagen por tipo de junta (usa tus archivos en assets/joints) ===
 const JOINT_IMAGES = {
-  pipe_union_welded_brazed: 'welded_brazed.png',
-  comp_swage: 'compression_swage.png',
-  comp_bite: 'compression_bite.png',
-  comp_typical: 'compression_typical.png',
-  comp_flared: 'compression_flared.png',
-  comp_press: 'compression_press.png',
-  slip_mgrooved: 'slip_machine_grooved.png',
-  slip_grip: 'slip_grip.png',
-  slip_type: 'slip_slip.png'
+  pipe_union_welded_brazed: 'welded_brazed.jpg',
+  comp_swage: 'compression_swage.jpg',
+  comp_bite: 'compression_bite.jpg',
+  comp_typical: 'compression_typical.jpg',
+  comp_flared: 'compression_flared.jpg',
+  comp_press: 'compression_press.jpg',
+  slip_mgrooved: 'slip_machine_grooved.jpg',
+  slip_grip: 'slip_grip.jpg',
+  slip_type: 'slip_slip.jpg'
 };
 function jointImgPath(key){
   return 'assets/joints/' + (JOINT_IMAGES[key] || 'not-found.jpg');

--- a/juntas_ships.html
+++ b/juntas_ships.html
@@ -97,15 +97,15 @@
 <script>
 /* ========= IMÁGENES por tipo ========= */
 const JOINT_IMAGES = {
-  pipe_union_welded_brazed: ['welded_brazed.png','pipe_welded_brazed.jpg'],
-  comp_swage: ['compression_swage.png','compression_swage.jpg'],
-  comp_bite: ['compression_bite.png','compression_bite.jpg'],
-  comp_typical: ['compression_typical.png','compression_typical.jpg'],
-  comp_flared: ['compression_flared.png','compression_flared.jpg'],
-  comp_press: ['compression_press.png','compression_press.jpg'],
-  slip_mgrooved: ['slip_machine_grooved.png','slip_machine_grooved.jpg'],
-  slip_grip: ['slip_grip.png','slip_grip.jpg'],
-  slip_type: ['slip_slip.png','slip_slip.jpg'],
+  pipe_union_welded_brazed: ['welded_brazed.jpg','welded_brazed.png'],
+  comp_swage: ['compression_swage.jpg','compression_swage.png'],
+  comp_bite: ['compression_bite.jpg','compression_bite.png'],
+  comp_typical: ['compression_typical.jpg','compression_typical.png'],
+  comp_flared: ['compression_flared.jpg','compression_flared.png'],
+  comp_press: ['compression_press.jpg','compression_press.png'],
+  slip_mgrooved: ['slip_machine_grooved.jpg','slip_machine_grooved.png'],
+  slip_grip: ['slip_grip.jpg','slip_grip.png'],
+  slip_type: ['slip_slip.jpg','slip_slip.png'],
 };
 const jointImgPath = k => 'assets/joints/' + (JOINT_IMAGES[k]?.[0] || 'not-found.jpg');
 

--- a/src/components/Evaluator.tsx
+++ b/src/components/Evaluator.tsx
@@ -3,15 +3,15 @@ import type { Dataset, ClassName, System, JointKey } from '../core/types';
 import { evaluate, type EvalItem } from '../core/evaluator';
 
 const JOINT_IMAGES: Record<string, string> = {
-  pipe_union_welded_brazed: 'welded_brazed.png',
-  comp_swage: 'compression_swage.png',
-  comp_bite: 'compression_bite.png',
-  comp_typical: 'compression_typical.png',
-  comp_flared: 'compression_flared.png',
-  comp_press: 'compression_press.png',
-  slip_mgrooved: 'slip_machine_grooved.png',
-  slip_grip: 'slip_grip.png',
-  slip_type: 'slip_slip.png',
+  pipe_union_welded_brazed: 'welded_brazed.jpg',
+  comp_swage: 'compression_swage.jpg',
+  comp_bite: 'compression_bite.jpg',
+  comp_typical: 'compression_typical.jpg',
+  comp_flared: 'compression_flared.jpg',
+  comp_press: 'compression_press.jpg',
+  slip_mgrooved: 'slip_machine_grooved.jpg',
+  slip_grip: 'slip_grip.jpg',
+  slip_type: 'slip_slip.jpg',
 };
 
 const jointImgPath = (k: string) => `assets/joints/${JOINT_IMAGES[k] ?? 'not-found.jpg'}`;


### PR DESCRIPTION
## Summary
- add shared navigation and branding styles for reuse across pages
- update index and tool pages to show the unified header and hero logo, removing outdated links
- fix joint image mappings to reference the available .jpg assets in HTML and React components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e66dfa315c8321a5b558f4da34b37c