### PR TITLE
Align LR branding across pages and refresh joint evaluator cards

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -111,9 +111,11 @@ small,
   margin: 12px 0 16px;
 }
 
-.page-header .left {
+.page-header .logo-wrapper {
+  margin-left: auto;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 16px;
 }
 

--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -382,11 +382,10 @@
 <body>
 <div class="wrap">
   <header class="page-header">
-    <div class="left">
-      <a href="index.html" class="back-link">← Volver al inicio</a>
+    <a href="index.html" class="back-link">← Volver al inicio</a>
+    <div class="logo-wrapper">
       <img src="assets/joints/cotec.jpg" alt="COTECMAR" class="brand-logo">
     </div>
-    <div></div>
   </header>
   <section class="relative hero-pr max-w-6xl mx-auto px-6">
     <h1 class="hero-title font-extrabold">

--- a/index.html
+++ b/index.html
@@ -23,29 +23,54 @@
       font-family: Inter,system-ui,-apple-system,"Segoe UI","Helvetica Neue",sans-serif;
     }
     main {
-      width: min(680px, 92vw);
-      padding: 42px 32px 46px;
-      border-radius: 28px;
+      width: min(720px, 92vw);
+      padding: 44px 34px 50px;
+      border-radius: 30px;
       border: 1px solid var(--border);
-      background: rgba(15,23,42,.78);
+      background: rgba(15,23,42,.82);
       box-shadow: 0 28px 60px rgba(2,6,23,.55);
+      backdrop-filter: blur(18px);
+    }
+    .main-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 24px;
+      margin-bottom: 26px;
+    }
+    .titles {
+      display: grid;
+      gap: 14px;
     }
     h1 {
-      margin: 0 0 18px;
-      font-size: clamp(26px, 4vw, 36px);
+      margin: 0;
+      font-size: clamp(28px, 4vw, 38px);
     }
-    p {
-      margin: 0 0 24px;
+    .titles p {
+      margin: 0;
       color: var(--mut);
-      line-height: 1.6;
+      line-height: 1.7;
       font-size: 15px;
+    }
+    .logo-wrapper {
+      flex-shrink: 0;
+      display: flex;
+      align-items: flex-start;
+      justify-content: flex-end;
+    }
+    .brand-logo {
+      width: 120px;
+      height: auto;
+      border-radius: 14px;
+      box-shadow: 0 10px 30px rgba(2,6,23,.55);
     }
     ul {
       list-style: none;
       margin: 0;
       padding: 0;
       display: grid;
-      gap: 16px;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     }
     a.card {
       display: flex;
@@ -73,6 +98,15 @@
       background: rgba(30,41,59,.85);
       outline: none;
     }
+    @media (max-width: 640px) {
+      .main-head {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      .logo-wrapper {
+        justify-content: flex-start;
+      }
+    }
     footer {
       margin-top: 26px;
       font-size: 13px;
@@ -83,11 +117,15 @@
 </head>
 <body>
   <main>
-    <h1>Herramientas de compatibilidad LR</h1>
-    <div class="branding">
-      <img src="assets/joints/cotec.jpg" alt="COTECMAR" class="brand-logo">
-    </div>
-    <p>Selecciona la herramienta que desees consultar. Ambas páginas funcionan con rutas relativas, por lo que se pueden abrir directamente desde GitHub Pages o de forma local sin configuración adicional.</p>
+    <header class="main-head">
+      <div class="titles">
+        <h1>Herramientas de compatibilidad LR</h1>
+        <p>Selecciona la herramienta que desees consultar. Ambas páginas funcionan con rutas relativas, por lo que se pueden abrir directamente desde GitHub Pages o de forma local sin configuración adicional.</p>
+      </div>
+      <div class="logo-wrapper">
+        <img src="assets/joints/cotec.jpg" alt="COTECMAR" class="brand-logo">
+      </div>
+    </header>
     <ul>
       <li>
         <a class="card" href="juntas.html">

--- a/juntas.html
+++ b/juntas.html
@@ -6,60 +6,331 @@
 <title>Evaluador de juntas · LR (Naval/Ships)</title>
 <link rel="stylesheet" href="assets/css/app.css">
 <style>
-  :root{
-    --ink:#0f172a; --mut:#64748b; --card:#ffffff; --border:#e2e8f0;
-    --ok:#10b981; --warn:#f59e0b; --bad:#f43f5e; --group:#f8fafc;
+  :root {
+    --ink: #e2e8f0;
+    --mut: rgba(148, 163, 184, 0.78);
+    --card: rgba(15, 23, 42, 0.82);
+    --border: rgba(148, 163, 184, 0.22);
+    --ok: #34d399;
+    --warn: #fbbf24;
+    --bad: #f87171;
+    --group: rgba(15, 23, 42, 0.62);
   }
-  body{background:#0b1220;color:#e5e7eb}
-  .wrap{max-width:1200px;margin:0 auto;padding:16px}
-  .page-header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin:12px 0 20px}
-  .page-header .logo-wrapper{margin-left:auto;display:flex;align-items:center;justify-content:flex-end}
-  .page-header .brand-logo{width:120px;height:auto;border-radius:12px;box-shadow:0 6px 20px rgba(0,0,0,.25)}
-  .h1{font-size:20px;font-weight:700;margin:0 0 12px}
-  .controls{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}
-  .card{background:var(--card); color:#0f172a; border:1px solid var(--border); border-radius:16px; padding:14px}
-  .lbl{display:block;font-size:12px;color:#475569;margin:0 0 6px}
-  select,input[type="number"]{width:100%;border:1px solid var(--border);border-radius:12px;padding:8px}
-  .checks{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:10px;margin-top:8px}
-  .check-item{display:flex;flex-direction:column;gap:4px;font-size:13px}
-  .check-item input{margin-right:6px}
-  .check-item label{font-size:13px;color:#1f2937}
-  .btn{background:#0f172a;color:#fff;border:0;border-radius:10px;padding:10px 14px;font-size:14px;cursor:pointer}
-  .btn:hover{opacity:.9}
-  .badge{font-size:12px;border-radius:999px;border:1px solid;padding:2px 8px;font-weight:700}
-  .b-ok{color:#065f46;border-color:#34d399;background:#d1fae5}
-  .b-warn{color:#7c2d12;border-color:#fbbf24;background:#fef3c7}
-  .b-bad{color:#7f1d1d;border-color:#fda4af;background:#ffe4e6}
-  .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}
-  .group{background:var(--group); border:1px solid #e2e8f0; border-radius:18px; padding:12px}
-  .g-title{font-weight:700;font-size:14px}
-  .g-sub{font-size:12px;color:#64748b;margin-top:2px}
-  #notesChips,#generalChips{display:flex;flex-wrap:wrap;gap:8px}
-  .chip,.note-chip,.rule-chip{font-size:11px;border-radius:999px;border:1px solid #93c5fd;background:#dbeafe;color:#1e3a8a;padding:2px 8px;cursor:pointer}
-  .mt-2{margin-top:8px}.mt-3{margin-top:12px}.mt-4{margin-top:16px}.mb-2{margin-bottom:8px}.mb-3{margin-bottom:12px}
-  .mut{color:#64748b}.small{font-size:12px}
-  .reasons{margin:6px 0 0 16px;font-size:12px}
-  .view-action{margin-top:16px;display:flex;justify-content:flex-end}
-  .view-btn{display:inline-flex;align-items:center;justify-content:center;font-size:13px;font-weight:600;letter-spacing:.04em;padding:9px 22px;border-radius:999px;border:0;background:#0ea5e9;color:#0f172a;cursor:pointer;transition:background-color .2s ease,transform .2s ease,box-shadow .2s ease}
-  .view-btn:hover{background:#38bdf8;transform:translateY(-1px);box-shadow:0 8px 18px rgba(14,165,233,.25)}
-  .view-btn:active{transform:translateY(0)}
-  .empty-state{padding:26px;border-radius:16px;border:1px dashed #cbd5f5;background:rgba(226,232,240,.4);color:#1f2937;font-size:14px;text-align:center}
-  .empty-state strong{color:#0f172a}
+  body {
+    margin: 0;
+    background: radial-gradient(circle at top, #1e293b 0%, #0f172a 55%, #020617 100%);
+    color: var(--ink);
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  }
+  .wrap {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 28px 24px 48px;
+  }
+  .page-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin: 12px 0 24px;
+  }
+  .page-header .logo-wrapper {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+  .page-header .brand-logo {
+    width: 120px;
+    height: auto;
+    border-radius: 14px;
+    box-shadow: 0 10px 30px rgba(2, 6, 23, 0.55);
+  }
+  .h1 {
+    font-size: clamp(24px, 3vw, 34px);
+    font-weight: 700;
+    margin: 0 0 18px;
+  }
+  .card {
+    background: linear-gradient(150deg, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.72));
+    color: var(--ink);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 20px 22px;
+    box-shadow: 0 20px 45px rgba(2, 6, 23, 0.55);
+    backdrop-filter: blur(14px);
+  }
+  .controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 14px;
+  }
+  .lbl {
+    display: block;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--mut);
+    margin: 0 0 6px;
+  }
+  select,
+  input[type="number"] {
+    width: 100%;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 12px;
+    padding: 10px 12px;
+    background: rgba(15, 23, 42, 0.55);
+    color: var(--ink);
+    font-size: 14px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  select:focus,
+  input[type="number"]:focus {
+    border-color: rgba(56, 189, 248, 0.7);
+    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+    outline: none;
+  }
+  .checks {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 12px;
+    margin-top: 12px;
+  }
+  .check-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--ink);
+  }
+  .check-item input {
+    margin-top: 3px;
+  }
+  .check-item label {
+    font-size: 13px;
+    color: var(--ink);
+    line-height: 1.45;
+  }
+  .btn {
+    background: #0ea5e9;
+    color: #041628;
+    border: 0;
+    border-radius: 12px;
+    padding: 11px 18px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    box-shadow: 0 12px 30px rgba(14, 165, 233, 0.32);
+  }
+  .btn:hover {
+    background: #38bdf8;
+    transform: translateY(-1px);
+    box-shadow: 0 16px 34px rgba(14, 165, 233, 0.34);
+  }
+  .badge {
+    font-size: 12px;
+    border-radius: 999px;
+    border: 1px solid;
+    padding: 3px 10px;
+    font-weight: 700;
+  }
+  .b-ok {
+    color: #4ade80;
+    border-color: rgba(74, 222, 128, 0.5);
+    background: rgba(21, 128, 61, 0.35);
+  }
+  .b-warn {
+    color: #facc15;
+    border-color: rgba(250, 204, 21, 0.55);
+    background: rgba(120, 53, 15, 0.35);
+  }
+  .b-bad {
+    color: #f87171;
+    border-color: rgba(248, 113, 113, 0.55);
+    background: rgba(127, 29, 29, 0.35);
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 14px;
+  }
+  .group {
+    background: var(--group);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-radius: 18px;
+    padding: 16px;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
+  }
+  .g-title {
+    font-weight: 700;
+    font-size: 14px;
+    color: var(--ink);
+  }
+  .g-sub {
+    font-size: 12px;
+    color: var(--mut);
+    margin-top: 4px;
+  }
+  #notesChips,
+  #generalChips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .chip,
+  .note-chip,
+  .rule-chip {
+    font-size: 11px;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(30, 41, 59, 0.85);
+    color: var(--ink);
+    padding: 4px 10px;
+    cursor: pointer;
+  }
+  .mt-1 { margin-top: 4px; }
+  .mt-2 { margin-top: 8px; }
+  .mt-3 { margin-top: 12px; }
+  .mt-4 { margin-top: 16px; }
+  .mb-2 { margin-bottom: 8px; }
+  .mb-3 { margin-bottom: 12px; }
+  .mut { color: var(--mut); }
+  .small { font-size: 12px; }
+  .reasons {
+    margin: 6px 0 0 18px;
+    font-size: 12px;
+    color: var(--mut);
+  }
+  .view-action {
+    margin-top: 18px;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .view-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    padding: 10px 24px;
+    border-radius: 999px;
+    border: 0;
+    background: #0ea5e9;
+    color: #041628;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 14px 28px rgba(14, 165, 233, 0.3);
+  }
+  .view-btn:hover {
+    background: #38bdf8;
+    transform: translateY(-1px);
+    box-shadow: 0 18px 34px rgba(14, 165, 233, 0.34);
+  }
+  .view-btn:active {
+    transform: translateY(0);
+  }
+  .empty-state {
+    padding: 26px;
+    border-radius: 18px;
+    border: 1px dashed rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.5);
+    color: var(--ink);
+    font-size: 14px;
+    text-align: center;
+  }
+  .empty-state strong {
+    color: #f8fafc;
+  }
   /* Modal imagen */
-  .modal{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:center;justify-content:center;padding:20px;z-index:20}
-  .modal.open{display:flex}
-  .modal .box{background:#0b1220;border:1px solid #334155;border-radius:12px;padding:18px;max-width:95vw;max-height:90vh;display:flex;flex-direction:column;align-items:center;gap:14px;position:relative}
-  .modal img{max-width:90vw;max-height:70vh;display:block;border-radius:12px}
-  .modal .close-btn{position:absolute;top:10px;right:10px;background:none;border:0;color:#94a3b8;font-size:24px;cursor:pointer;padding:4px}
-  .modal .close-btn:hover{color:#e2e8f0}
-  .modal-caption{font-size:14px;color:#cbd5f5;text-align:center}
-  .note-modal .box{max-width:520px;width:100%;padding:20px;color:#e5e7eb;display:grid;gap:16px}
-  .note-title{font-weight:700;font-size:16px}
-  .note-body{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;font-size:14px}
-  .note-lang{font-weight:600;color:#94a3b8;margin-bottom:4px}
-  .note-modal .close-btn{justify-self:flex-end;position:static}
-  .note-modal .close-btn:hover{color:#e2e8f0}
-  body.modal-open{overflow:hidden}
+  .modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    z-index: 20;
+  }
+  .modal.open {
+    display: flex;
+  }
+  .modal .box {
+    background: rgba(15, 23, 42, 0.92);
+    border: 1px solid rgba(51, 65, 85, 0.8);
+    border-radius: 14px;
+    padding: 18px;
+    max-width: 95vw;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    position: relative;
+    box-shadow: 0 24px 40px rgba(2, 6, 23, 0.6);
+  }
+  .modal img {
+    max-width: 90vw;
+    max-height: 70vh;
+    display: block;
+    border-radius: 12px;
+  }
+  .modal .close-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: 0;
+    color: rgba(148, 163, 184, 0.9);
+    font-size: 24px;
+    cursor: pointer;
+    padding: 4px;
+  }
+  .modal .close-btn:hover {
+    color: #e2e8f0;
+  }
+  .modal-caption {
+    font-size: 14px;
+    color: rgba(203, 213, 225, 0.85);
+    text-align: center;
+  }
+  .note-modal .box {
+    max-width: 520px;
+    width: 100%;
+    padding: 20px;
+    color: var(--ink);
+    display: grid;
+    gap: 16px;
+    background: rgba(15, 23, 42, 0.95);
+  }
+  .note-title {
+    font-weight: 700;
+    font-size: 16px;
+  }
+  .note-body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 12px;
+    font-size: 14px;
+  }
+  .note-lang {
+    font-weight: 600;
+    color: rgba(148, 163, 184, 0.85);
+    margin-bottom: 4px;
+  }
+  .note-modal .close-btn {
+    justify-self: flex-end;
+    position: static;
+  }
+  .note-modal .close-btn:hover {
+    color: #e2e8f0;
+  }
+  body.modal-open {
+    overflow: hidden;
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Align the home and compatibility pages with the new top-right branding layout for the COTECMAR logo.
- Update the shared header CSS to support the repositioned branding block.
- Refresh the joint evaluator UI with a darker card theme and refined control styling.

## Testing
- No automated tests were run (not applicable for these static HTML updates).

------
https://chatgpt.com/codex/tasks/task_e_68e67bd9e4a08321b5cd56f4ae01236e