### PR TITLE
Improve contrast and index card styling

### DIFF
--- a/compatibilidad.html
+++ b/compatibilidad.html
@@ -7,14 +7,14 @@
 <link rel="stylesheet" href="assets/css/app.css">
 <style>
   :root {
-    --bg: #0f172a;
-    --bg-soft: #1e293b;
-    --bg-card: rgba(15, 23, 42, 0.82);
-    --surface: rgba(15, 23, 42, 0.6);
-    --ink: #e2e8f0;
-    --ink-soft: rgba(226, 232, 240, 0.76);
-    --mut: rgba(148, 163, 184, 0.7);
-    --border: rgba(148, 163, 184, 0.18);
+    --bg: radial-gradient(circle at top, #1b2d4f 0%, #101c33 55%, #050b18 100%);
+    --bg-soft: rgba(21, 32, 52, 0.94);
+    --bg-card: linear-gradient(160deg, rgba(26, 38, 62, 0.95), rgba(12, 20, 36, 0.88));
+    --surface: rgba(18, 30, 48, 0.78);
+    --ink: #eef2f8;
+    --ink-soft: rgba(226, 232, 240, 0.88);
+    --mut: rgba(203, 213, 225, 0.74);
+    --border: rgba(148, 163, 184, 0.32);
     --accent: #38bdf8;
     --accent-2: #a855f7;
     --ok: #22c55e;
@@ -25,15 +25,34 @@
   html, body {
     margin: 0;
     min-height: 100%;
-    background: radial-gradient(circle at top, #1e293b 0%, #0f172a 55%, #020617 100%);
+    background: var(--bg);
     color: var(--ink);
     font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   }
   a { color: inherit; }
+  .site-footer {
+    margin: 64px 0 40px;
+    font-size: 13px;
+    color: rgba(203, 213, 225, 0.74);
+    text-align: center;
+  }
+  .site-footer .footer-wrap {
+    display: inline-grid;
+    gap: 6px;
+  }
+  .site-footer a {
+    color: inherit;
+    text-decoration: underline;
+  }
   .wrap {
     max-width: 1240px;
     margin: 0 auto;
-    padding: 48px 24px 64px;
+    padding: 52px 36px 72px;
+    background: var(--bg-soft);
+    border-radius: 36px;
+    border: 1px solid var(--border);
+    box-shadow: 0 42px 110px rgba(3, 9, 22, 0.6);
+    backdrop-filter: blur(24px);
   }
   .relative { position: relative; }
   .mt-3 { margin-top: 0.75rem; }
@@ -69,11 +88,11 @@
   }
   .card {
     background: var(--bg-card);
-    border-radius: 26px;
-    border: 1px solid var(--border);
-    padding: 28px;
-    box-shadow: 0 20px 45px rgba(2, 6, 23, 0.55);
-    backdrop-filter: blur(16px);
+    border-radius: 28px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    padding: 30px;
+    box-shadow: 0 28px 70px rgba(4, 11, 28, 0.55);
+    backdrop-filter: blur(18px);
   }
   .card.result { position: sticky; top: 32px; }
 
@@ -119,17 +138,18 @@
   }
   select, input[type="number"], input[type="text"] {
     width: 100%;
-    padding: 12px 14px;
-    border-radius: 14px;
-    border: 1px solid rgba(148, 163, 184, 0.35);
+    padding: 13px 15px;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
     background: var(--surface);
     color: var(--ink);
     font-size: 15px;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   }
   select:focus, input[type="number"]:focus, input[type="text"]:focus {
-    border-color: var(--accent);
-    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.3);
+    border-color: rgba(125, 211, 252, 0.85);
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.28);
+    background: rgba(29, 43, 72, 0.9);
     outline: none;
   }
   #daSelect { width: 100%; }

--- a/index.html
+++ b/index.html
@@ -8,9 +8,10 @@
   <style>
     :root {
       --ink: #e2e8f0;
-      --mut: rgba(148,163,184,.76);
-      --border: rgba(148,163,184,.18);
-      --bg: radial-gradient(circle at top,#1e293b 0%,#0f172a 55%,#020617 100%);
+      --mut: rgba(203,213,225,.82);
+      --border: rgba(148,163,184,.32);
+      --panel: linear-gradient(160deg, rgba(21,32,52,.97), rgba(9,15,29,.9));
+      --bg: radial-gradient(circle at top,#1b2d4f 0%,#0f1c33 55%,#040915 100%);
     }
     body {
       margin: 0;
@@ -23,13 +24,13 @@
       font-family: Inter,system-ui,-apple-system,"Segoe UI","Helvetica Neue",sans-serif;
     }
     main {
-      width: min(720px, 92vw);
-      padding: 44px 34px 50px;
-      border-radius: 30px;
+      width: min(860px, 94vw);
+      padding: 56px 48px 64px;
+      border-radius: 34px;
       border: 1px solid var(--border);
-      background: rgba(15,23,42,.82);
-      box-shadow: 0 28px 60px rgba(2,6,23,.55);
-      backdrop-filter: blur(18px);
+      background: var(--panel);
+      box-shadow: 0 36px 90px rgba(3,9,22,.6);
+      backdrop-filter: blur(26px);
     }
     .main-head {
       display: flex;
@@ -44,13 +45,14 @@
     }
     h1 {
       margin: 0;
-      font-size: clamp(28px, 4vw, 38px);
+      font-size: clamp(34px, 4.6vw, 46px);
+      letter-spacing: -.01em;
     }
     .titles p {
       margin: 0;
       color: var(--mut);
-      line-height: 1.7;
-      font-size: 15px;
+      line-height: 1.8;
+      font-size: clamp(16px, 1.6vw, 18px);
     }
     .logo-wrapper {
       flex-shrink: 0;
@@ -59,7 +61,7 @@
       justify-content: flex-end;
     }
     .brand-logo {
-      width: 120px;
+      width: clamp(130px, 16vw, 160px);
       height: auto;
       border-radius: 14px;
       box-shadow: 0 10px 30px rgba(2,6,23,.55);
@@ -69,34 +71,50 @@
       margin: 0;
       padding: 0;
       display: grid;
-      gap: 18px;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     }
     a.card {
       display: flex;
       flex-direction: column;
-      gap: 4px;
-      padding: 18px 20px;
-      border-radius: 20px;
-      border: 1px solid rgba(148,163,184,.25);
-      background: rgba(2,6,23,.55);
+      gap: 10px;
+      padding: 28px 30px;
+      border-radius: 24px;
+      border: 1px solid rgba(148,163,184,.38);
+      background: linear-gradient(140deg, rgba(30,41,59,.92), rgba(15,23,42,.82));
       color: inherit;
       text-decoration: none;
       transition: transform .18s ease, border-color .18s ease, background .18s ease;
     }
+    a.card.card-evaluator {
+      background: linear-gradient(145deg, rgba(47,72,118,.95), rgba(22,34,58,.88));
+      box-shadow: 0 18px 36px rgba(11,19,38,.55);
+    }
+    a.card.card-compat {
+      background: linear-gradient(145deg, rgba(40,66,94,.95), rgba(16,30,48,.88));
+      box-shadow: 0 18px 36px rgba(8,16,32,.5);
+    }
     a.card strong {
-      font-size: 17px;
+      font-size: clamp(20px, 2.2vw, 24px);
     }
     a.card span {
       color: var(--mut);
-      font-size: 14px;
+      font-size: clamp(15px, 1.6vw, 17px);
+      line-height: 1.8;
     }
     a.card:hover,
     a.card:focus-visible {
-      transform: translateY(-3px);
-      border-color: rgba(56,189,248,.65);
-      background: rgba(30,41,59,.85);
+      transform: translateY(-4px);
+      border-color: rgba(129,212,250,.8);
       outline: none;
+    }
+    a.card.card-evaluator:hover,
+    a.card.card-evaluator:focus-visible {
+      background: linear-gradient(150deg, rgba(64,97,158,.98), rgba(20,31,52,.9));
+    }
+    a.card.card-compat:hover,
+    a.card.card-compat:focus-visible {
+      background: linear-gradient(150deg, rgba(58,90,124,.98), rgba(18,28,46,.9));
     }
     @media (max-width: 640px) {
       .main-head {
@@ -107,11 +125,19 @@
         justify-content: flex-start;
       }
     }
-    footer {
-      margin-top: 26px;
+    .site-footer {
+      margin-top: 46px;
       font-size: 13px;
-      color: rgba(148,163,184,.65);
+      color: rgba(203,213,225,.74);
       text-align: center;
+    }
+    .site-footer .footer-wrap {
+      display: inline-grid;
+      gap: 6px;
+    }
+    .site-footer a {
+      color: inherit;
+      text-decoration: underline;
     }
   </style>
 </head>
@@ -128,19 +154,24 @@
     </header>
     <ul>
       <li>
-        <a class="card" href="juntas.html">
+        <a class="card card-evaluator" href="juntas.html">
           <strong>Evaluador de juntas LR</strong>
           <span>Evalúa rápidamente la aceptación de juntas mecánicas por norma, sistema y espacio.</span>
         </a>
       </li>
       <li>
-        <a class="card" href="compatibilidad.html">
+        <a class="card card-compat" href="compatibilidad.html">
           <strong>Compatibilidad de tuberías</strong>
           <span>Explora combinaciones de materiales y obtén notas de compatibilidad.</span>
         </a>
       </li>
     </ul>
-    <footer>© Lloyd's Register · Referencia interna de compatibilidad de tuberías.</footer>
+    <footer class="site-footer">
+      <div class="footer-wrap">
+        <div>Por <strong>Jhon Eric Gomez</strong> – DVMPR-GEDIN</div>
+        <div>Para consultas contactar a: <a href="mailto:jegomez@cotecmar.com">jegomez@cotecmar.com</a></div>
+      </div>
+    </footer>
   </main>
 </body>
 </html>

--- a/juntas.html
+++ b/juntas.html
@@ -7,25 +7,44 @@
 <link rel="stylesheet" href="assets/css/app.css">
 <style>
   :root {
-    --ink: #e2e8f0;
-    --mut: rgba(148, 163, 184, 0.78);
-    --card: rgba(15, 23, 42, 0.82);
-    --border: rgba(148, 163, 184, 0.22);
+    --ink: #eef2f8;
+    --mut: rgba(203, 213, 225, 0.78);
+    --card: linear-gradient(160deg, rgba(27, 40, 66, 0.95), rgba(12, 19, 34, 0.88));
+    --border: rgba(148, 163, 184, 0.34);
     --ok: #34d399;
     --warn: #fbbf24;
     --bad: #f87171;
-    --group: rgba(15, 23, 42, 0.62);
+    --group: rgba(22, 34, 54, 0.72);
   }
   body {
     margin: 0;
-    background: radial-gradient(circle at top, #1e293b 0%, #0f172a 55%, #020617 100%);
+    background: radial-gradient(circle at top, #1b2d4f 0%, #0f1c33 55%, #040915 100%);
     color: var(--ink);
     font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  }
+  .site-footer {
+    margin: 60px 0 38px;
+    text-align: center;
+    font-size: 13px;
+    color: rgba(203, 213, 225, 0.74);
+  }
+  .site-footer .footer-wrap {
+    display: inline-grid;
+    gap: 6px;
+  }
+  .site-footer a {
+    color: inherit;
+    text-decoration: underline;
   }
   .wrap {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 28px 24px 48px;
+    padding: 40px 32px 60px;
+    background: linear-gradient(160deg, rgba(19, 31, 52, 0.94), rgba(8, 15, 30, 0.88));
+    border-radius: 34px;
+    border: 1px solid rgba(148, 163, 184, 0.32);
+    box-shadow: 0 40px 110px rgba(3, 9, 22, 0.6);
+    backdrop-filter: blur(24px);
   }
   .page-header {
     display: flex;
@@ -52,13 +71,13 @@
     margin: 0 0 18px;
   }
   .card {
-    background: linear-gradient(150deg, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.72));
+    background: var(--card);
     color: var(--ink);
     border: 1px solid var(--border);
-    border-radius: 20px;
-    padding: 20px 22px;
-    box-shadow: 0 20px 45px rgba(2, 6, 23, 0.55);
-    backdrop-filter: blur(14px);
+    border-radius: 24px;
+    padding: 24px 26px;
+    box-shadow: 0 28px 70px rgba(4, 11, 28, 0.55);
+    backdrop-filter: blur(18px);
   }
   .controls {
     display: grid;
@@ -77,18 +96,19 @@
   select,
   input[type="number"] {
     width: 100%;
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    border-radius: 12px;
-    padding: 10px 12px;
-    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    border-radius: 16px;
+    padding: 12px 14px;
+    background: rgba(23, 35, 57, 0.78);
     color: var(--ink);
     font-size: 14px;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   }
   select:focus,
   input[type="number"]:focus {
-    border-color: rgba(56, 189, 248, 0.7);
-    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+    border-color: rgba(125, 211, 252, 0.85);
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.28);
+    background: rgba(31, 48, 78, 0.9);
     outline: none;
   }
   .checks {
@@ -158,10 +178,10 @@
   }
   .group {
     background: var(--group);
-    border: 1px solid rgba(148, 163, 184, 0.16);
-    border-radius: 18px;
-    padding: 16px;
-    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    border-radius: 20px;
+    padding: 18px;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.22);
   }
   .g-title {
     font-weight: 700;
@@ -1451,5 +1471,11 @@ renderNotesLegend(initialDataset);
 showContextualChecks(initialDataset);
 clearResultsAndHints();
 </script>
+  <footer class="site-footer">
+    <div class="footer-wrap">
+      <div>Por <strong>Jhon Eric Gomez</strong> – DVMPR-GEDIN</div>
+      <div>Para consultas contactar a: <a href="mailto:jegomez@cotecmar.com">jegomez@cotecmar.com</a></div>
+    </div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the index landing panel with higher-contrast styling and distinct gradient cards for each tool
- increase background separation and input contrast on the compatibilidad and juntas views for clearer legibility

## Testing
- not run (static pages)


------
https://chatgpt.com/codex/tasks/task_e_68e68de08f888321a50bac5370998111