### PR TITLE
Always hide axial compensation control

### DIFF
--- a/juntas.html
+++ b/juntas.html
@@ -476,7 +476,7 @@
             </select>
           </div>
         </div>
-        <div class="check-item axial-control">
+        <div class="check-item axial-control" style="display:none;">
           <div class="check-text">
             <label for="axialSelect">(Slip type) Requiere compensación axial</label>
             <select id="axialSelect">
@@ -1467,9 +1467,7 @@ function showContextualChecks(dataset){
     }
   }
 
-  const systemAllowsSlipType = Boolean(sys?.allow?.slip_type);
-  const classAllowsSlipType = dataset.CLASS_RULES?.slip_type?.[pipeClass]?.allowed !== false;
-  const needsAxial = (systemAllowsSlipType && classAllowsSlipType) || sys?.key === 'steam';
+  const needsAxial = false;
   if(axialWrap){
     axialWrap.style.display = needsAxial ? '' : 'none';
     if(axialSel){


### PR DESCRIPTION
## Summary
- keep the slip type axial compensation control hidden at all times so users cannot toggle it
- default the hidden control to "no" to preserve existing evaluation behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690cc1582ce08321b8833dd96ebf4db0