### PR TITLE
Initialize evaluator selects with empty defaults

### DIFF
--- a/src/components/Evaluator.tsx
+++ b/src/components/Evaluator.tsx
@@ -57,11 +57,9 @@ export default function Evaluator({ dataset }: Props) {
   const [evaluated, setEvaluated] = useState<boolean>(false);
 
   useEffect(() => {
-    const firstGroup = dataset.SYSTEM_GROUPS[0];
-    const firstSystem = firstGroup?.systems[0];
-    setSystemKey(firstSystem?.key ?? '');
+    setSystemKey('');
     setPipeClass(null);
-    setSpace(dataset.SPACES[0]?.key ?? '');
+    setSpace('');
     setOd('');
     setVisible(false);
     setSameMedium(true);
@@ -102,7 +100,7 @@ export default function Evaluator({ dataset }: Props) {
   const generalNotes = useMemo(() => Object.values(dataset.GENERAL), [dataset.GENERAL]);
 
   const handleEvaluate = () => {
-    if (!systemKey || !pipeClass) return;
+    if (!systemKey || !pipeClass || !space) return;
     const numericOd = od.trim() === '' ? NaN : Number(od);
     const evalResults = evaluate(
       dataset,
@@ -135,6 +133,7 @@ export default function Evaluator({ dataset }: Props) {
           <div className="form-field">
             <label>Sistema / línea</label>
             <select value={systemKey} onChange={e => setSystemKey(e.target.value)}>
+              <option value="" disabled hidden={systemKey !== ''}>Selecciona sistema</option>
               {dataset.SYSTEM_GROUPS.map(group => (
                 <optgroup key={group.key} label={group.label}>
                   {group.systems.map(system => (
@@ -162,6 +161,7 @@ export default function Evaluator({ dataset }: Props) {
           <div className="form-field">
             <label>Espacio / ubicación</label>
             <select value={space} onChange={e => setSpace(e.target.value)}>
+              <option value="" disabled hidden={space !== ''}>Selecciona espacio</option>
               {dataset.SPACES.map(sp => (
                 <option key={sp.key} value={sp.key}>{sp.label}</option>
               ))}

--- a/src/components/StandardSelector.tsx
+++ b/src/components/StandardSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import Evaluator from './Evaluator';
 import { datasetNaval } from '../data/lr-naval';
 import { datasetShips } from '../data/lr-ships';
@@ -8,17 +8,24 @@ const DATASETS = { naval: datasetNaval, ships: datasetShips } as const;
 type DatasetKey = keyof typeof DATASETS;
 
 export default function StandardSelector(){
-  const [std, setStd] = useState<DatasetKey>('naval');
+  const [std, setStd] = useState<DatasetKey | ''>('');
+  const dataset = useMemo(() => (std ? DATASETS[std] : null), [std]);
+
   return (
     <div className="selector-shell">
       <div className="selector-bar">
         <label className="selector-label">Norma</label>
-        <select className="selector-select" value={std} onChange={e=>setStd(e.target.value as DatasetKey)}>
+        <select
+          className="selector-select"
+          value={std}
+          onChange={e => setStd(e.target.value as DatasetKey | '')}
+        >
+          <option value="" disabled hidden={std !== ''}>Selecciona norma</option>
           <option value="naval">LR Naval</option>
           <option value="ships">LR Ships</option>
         </select>
       </div>
-      <Evaluator dataset={DATASETS[std]} />
+      {dataset && <Evaluator dataset={dataset} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- require selecting a norma before rendering the evaluator and add a placeholder option
- reset evaluator form fields when switching datasets and add placeholders for system and space selections
- prevent running evaluations until all mandatory selections are provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690d02744bcc832192fe112c7da8b792